### PR TITLE
Remove namespace manifest from vcluster deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ helm install workflows-cluster charts/workflows-cluster
 
 Secondly, deploy the workflows service in the virtual cluster:
 ```sh
-vcluster connect workflows-cluster -- helm install workflows charts/workflows -n workflows
+vcluster connect workflows-cluster -- helm install workflows charts/workflows -n workflows --create-namespace
 ```
 
 ## Deployment in developer mode
@@ -25,7 +25,7 @@ helm install workflows-cluster charts/workflows-cluster -f charts/workflows-clus
 
 Secondly, deploy the workflows service in the virtual cluster using the developer manifest :
 ```sh
-vcluster connect workflows-cluster -- helm install workflows charts/workflows -n workflows -f charts/workflows/dev-values.yaml
+vcluster connect workflows-cluster -- helm install workflows charts/workflows -n workflows -f charts/workflows/dev-values.yaml --create-namespace
 ```
 Note that for getting the workflows-server to run inside the dev environment it is necessary to extract the argo-server-sso secret, delete the deployed sealed secret and then deploy a new sealed secret using ```kubectl create -f <SEALED-SECRET>``` inside the virtual cluster.
 

--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   - name: vcluster

--- a/charts/workflows-cluster/values.yaml
+++ b/charts/workflows-cluster/values.yaml
@@ -24,13 +24,6 @@ vcluster:
           to: argo-workflows-server
   experimental:
     deploy:
-      manifests: |-
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: workflows
-          labels:
-            name: workflows
       helm:
         - chart:
             name: sealed-secrets


### PR DESCRIPTION
The VCluster deployment installs helm charts with `--create-namespace`, so this is not required