### PR TITLE
Use k8s vcluster with separate etcd

### DIFF
--- a/charts/workflows-cluster/Chart.lock
+++ b/charts/workflows-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: vcluster
   repository: https://charts.loft.sh
-  version: 0.20.0-beta.2
-digest: sha256:625342de992560e0ba29241dd3e4371074895d1332e906575948500f7d1aca24
-generated: "2024-05-17T10:05:17.516088419+01:00"
+  version: 0.20.0-beta.5
+digest: sha256:920a1fe91608fb52f6bff6dec3344925cf587d35a01be28ec02b428ee76b6f2b
+generated: "2024-05-22T15:25:20.522618879+01:00"

--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,9 +3,9 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.1.2
+version: 0.2.0
 
 dependencies:
   - name: vcluster
     repository: https://charts.loft.sh
-    version: 0.20.0-beta.2
+    version: 0.20.0-beta.5

--- a/charts/workflows-cluster/dev-values.yaml
+++ b/charts/workflows-cluster/dev-values.yaml
@@ -1,5 +1,21 @@
 vcluster:
   controlPlane:
+    backingStore:
+      etcd:
+        deploy:
+          statefulSet:
+            resources:
+              limits:
+                cpu: 200m
+                memory: 500Mi
+              requests:
+                cpu: 100m
+                memory: 250Mi
+            highAvailability:
+              replicas: 1
+            persistence:
+              volumeClaim:
+                storageClass: netapp
     coredns:
       deployment:
         replicas: 1
@@ -13,9 +29,6 @@ vcluster:
     statefulSet:
       highAvailability:
         replicas: 1
-      persistence:
-        volumeClaim:
-          storageClass: netapp
       resources:
         limits:
           cpu: 500m

--- a/charts/workflows-cluster/values.yaml
+++ b/charts/workflows-cluster/values.yaml
@@ -12,6 +12,8 @@ vcluster:
           requests:
             cpu: 100m
     statefulSet:
+      image:
+        repository: ghcr.io/loft-sh/vcluster-oss
       highAvailability:
         replicas: 3
       persistence:

--- a/charts/workflows-cluster/values.yaml
+++ b/charts/workflows-cluster/values.yaml
@@ -2,9 +2,20 @@ vcluster:
   telemetry:
     enabled: false
   controlPlane:
-    distro:
-      k0s:
-        enabled: true
+    backingStore:
+      etcd:
+        deploy:
+          enabled: true
+          statefulSet:
+            resources:
+              requests:
+                cpu: 100m
+                memory: 500Mi
+            highAvailability:
+              replicas: 3
+            persistence:
+              volumeClaim:
+                storageClass: db-nvme-storage
     coredns:
       deployment:
         replicas: 3
@@ -16,9 +27,6 @@ vcluster:
         repository: ghcr.io/loft-sh/vcluster-oss
       highAvailability:
         replicas: 3
-      persistence:
-        volumeClaim:
-          storageClass: db-nvme-storage
   networking:
     replicateServices:
       toHost:


### PR DESCRIPTION
This PR aims to resolve 'split brain' issues seen with the HA k0s deployment

- [x] Upgrade vcluster helm chart to `0.20.0-beta.5`
- [x] Switch to k8s distro
- [x] Deploy etcd separately 