### PR TITLE
Deploy only external charts in dev cluster

### DIFF
--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: vcluster

--- a/charts/workflows-cluster/dev-values.yaml
+++ b/charts/workflows-cluster/dev-values.yaml
@@ -37,6 +37,18 @@ vcluster:
         requests:
           cpu: 250m
           memory: 500Mi
+  experimental:
+    deploy:
+      helm:
+        - chart:
+            name: sealed-secrets
+            version: 2.15.3
+            repo: https://bitnami-labs.github.io/sealed-secrets
+          release:
+            name: sealed-secrets
+            namespace: kube-system
+          values: |-
+            fullnameOverride: sealed-secrets-controller
 
 ingress:
   enabled: false


### PR DESCRIPTION
Removes `workflows` chart deployment from `workflows-cluster` `dev-values.yaml`