### PR TITLE
Patch to fix manual deployment of argo-events in workflow namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ vcluster connect workflows-cluster -- helm install workflows charts/workflows -n
 
 Finally, deploy the events service in the virtual cluster:
 ```sh
-vcluster connect workflows-cluster -- helm install workflows charts/events -n events --create-namespace
+vcluster connect workflows-cluster -- helm install events charts/events -n events --create-namespace
 ```
 
 ## Deployment in developer mode
@@ -36,7 +36,7 @@ Note that for getting the workflows-server to run inside the dev environment it 
 
 Finally, deploy the events service in the virtual cluster using the developer manifest:
 ```sh
-vcluster connect workflows-cluster -- helm install workflows charts/events -n events -f charts/events/dev-values.yaml --create-namespace
+vcluster connect workflows-cluster -- helm install events charts/events -n events -f charts/events/dev-values.yaml --create-namespace
 ```
 
 ## Serve Docs

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -3,7 +3,7 @@ name: events
 description: Data Analysis event triggering
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   - name: argo-events

--- a/charts/events/templates/event-bus.yaml
+++ b/charts/events/templates/event-bus.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/eventbus/native.yaml
-{{- if .Values.argoevents.enabled }}
+{{- if index .Values "argo-events" "enabled" }}
   {{- range $eventBus := $.Values.eventBuses }}
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/charts/events/templates/event-sources.yaml
+++ b/charts/events/templates/event-sources.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.argoevents.enabled }}
+{{- if index .Values "argo-events" "enabled" }}
   {{- range $eventSource := $.Values.eventSources }}
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/charts/events/values.yaml
+++ b/charts/events/values.yaml
@@ -21,6 +21,11 @@ argo-events:
 eventBuses:
   - name: default
     namespace: events
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        cpu: 100m
 
 eventSources:
   - name: webhook


### PR DESCRIPTION
Using a dependency alias ```argoevents``` to simplify the syntax of the templates, did not work as expected for the manual deployment of argo-events in the workspace domain. Reverting back to less nice syntax in templates. We can try switch to using the alias once we deploy automatically with Argo CD. 