### PR TITLE
Fix `Sessionspaces` `clippy` warnings

### DIFF
--- a/sessionspaces/src/permissionables/posix_attributes.rs
+++ b/sessionspaces/src/permissionables/posix_attributes.rs
@@ -1,16 +1,18 @@
 use ldap3::{Ldap, LdapError, Scope, SearchEntry};
 use std::collections::BTreeMap;
 
-#[derive(Clone)]
+/// The posix attributes of a beamline session group
+#[derive(Debug, Clone)]
 pub struct PosixAttributes {
+    /// The unique identifier of the session
     pub session_name: String,
+    /// The posix Group ID of the session group
     pub gid: String,
 }
 
 impl PosixAttributes {
-    pub async fn fetch_gid(
-        ldap: &mut Ldap,
-    ) -> Result<BTreeMap<String, PosixAttributes>, LdapError> {
+    /// Fetches [`PosixAttributes`] from the SciComp LDAP
+    pub async fn fetch(ldap: &mut Ldap) -> Result<BTreeMap<String, PosixAttributes>, LdapError> {
         let (rs, _res) = ldap
             .search(
                 "ou=Group,dc=diamond,dc=ac,dc=uk",
@@ -25,7 +27,7 @@ impl PosixAttributes {
         for entry in rs {
             if let Some(gid) = SearchEntry::construct(entry.clone()).attrs.get("gidNumber") {
                 if let Some(session_name) = SearchEntry::construct(entry.clone()).attrs.get("cn") {
-                    let session_name_str = session_name.concat().replace("_", "-");
+                    let session_name_str = session_name.concat().replace('_', "-");
 
                     posix_attr.insert(
                         session_name_str.clone(),
@@ -40,4 +42,3 @@ impl PosixAttributes {
         Ok(posix_attr)
     }
 }
-    

--- a/sessionspaces/src/permissionables/session.rs
+++ b/sessionspaces/src/permissionables/session.rs
@@ -66,7 +66,7 @@ impl TryFrom<SessionRow> for Session {
         }?;
 
         let visit = match value.visit {
-            Some(visit) if visit == 0 => Err(anyhow::anyhow!("Visit number was zero")),
+            Some(0) => Err(anyhow::anyhow!("Visit number was zero")),
             Some(visit) => Ok(visit),
             None => Err(anyhow::anyhow!("Visit number was NULL")),
         }?;
@@ -78,7 +78,7 @@ impl TryFrom<SessionRow> for Session {
                 .proposal
                 .ok_or(anyhow::anyhow!("Proposal number was NULL"))?
                 .parse()?,
-            visit: visit,
+            visit,
         })
     }
 }

--- a/sessionspaces/src/resources/config_maps.rs
+++ b/sessionspaces/src/resources/config_maps.rs
@@ -6,7 +6,8 @@ use kube::{
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::{info, instrument};
 
-const CONFIG: &str = "sessionspaces";
+/// The name to be given to the ConfigMap
+const NAME: &str = "sessionspaces";
 
 #[instrument(skip(k8s_client))]
 pub async fn create_configmap(
@@ -37,14 +38,14 @@ pub async fn create_configmap(
     }
     configmaps
         .patch(
-            CONFIG,
+            NAME,
             &PatchParams {
                 field_manager: Some("kubectl".to_string()),
                 ..Default::default()
             },
             &Patch::Apply(&ConfigMap {
                 metadata: ObjectMeta {
-                    name: Some(CONFIG.to_string()),
+                    name: Some(NAME.to_string()),
                     ..Default::default()
                 },
                 data: Some(configmap_data),
@@ -53,6 +54,6 @@ pub async fn create_configmap(
         )
         .await?;
 
-    info!("ConfigMap {CONFIG} created");
+    info!("ConfigMap {NAME} created");
     Ok(())
 }

--- a/sessionspaces/src/resources/namespace.rs
+++ b/sessionspaces/src/resources/namespace.rs
@@ -22,7 +22,7 @@ pub async fn delete_namespace(
             info!("Namespace {namespace} does not exist, skipping deletion");
             Ok(())
         }
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 
@@ -52,7 +52,7 @@ pub async fn create_namespace(
             .await?;
             Ok(())
         }
-        Err(e) => Err(e.into()),
+        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
Fixes various warnings raised when running `cargo clippy`. Should allow #20 to pass