### PR TITLE
Add `managed-by` label to sessionspaces resources

### DIFF
--- a/sessionspaces/src/resources/config_maps.rs
+++ b/sessionspaces/src/resources/config_maps.rs
@@ -1,3 +1,4 @@
+use super::{MANAGED_BY, MANAGED_BY_LABEL};
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
     api::{ObjectMeta, Patch, PatchParams},
@@ -46,6 +47,10 @@ pub async fn create_configmap(
             &Patch::Apply(&ConfigMap {
                 metadata: ObjectMeta {
                     name: Some(NAME.to_string()),
+                    labels: Some(BTreeMap::from([(
+                        MANAGED_BY_LABEL.to_string(),
+                        MANAGED_BY.to_string(),
+                    )])),
                     ..Default::default()
                 },
                 data: Some(configmap_data),

--- a/sessionspaces/src/resources/mod.rs
+++ b/sessionspaces/src/resources/mod.rs
@@ -3,6 +3,11 @@ mod config_maps;
 /// The Namespace for a beamline session
 mod namespace;
 
+/// The app.kubernetes.io/managed-by label
+const MANAGED_BY_LABEL: &str = "app.kubernetes.io/managed-by";
+/// The value to be used in app.kubernetes.io/managed-by labels
+const MANAGED_BY: &str = "sessionspaces";
+
 pub use self::{
     config_maps::create_configmap,
     namespace::{create_namespace, delete_namespace},

--- a/sessionspaces/src/resources/namespace.rs
+++ b/sessionspaces/src/resources/namespace.rs
@@ -1,9 +1,11 @@
+use super::{MANAGED_BY, MANAGED_BY_LABEL};
 use k8s_openapi::api::core::v1::Namespace;
 use kube::Error as KubeError;
 use kube::{
     api::{DeleteParams, ObjectMeta, PostParams},
     Api,
 };
+use std::collections::BTreeMap;
 use tracing::{info, instrument};
 
 /// Removes a Namespace from the cluster
@@ -44,6 +46,10 @@ pub async fn create_namespace(
                 &Namespace {
                     metadata: ObjectMeta {
                         name: Some(namespace.clone()),
+                        labels: Some(BTreeMap::from([(
+                            MANAGED_BY_LABEL.to_string(),
+                            MANAGED_BY.to_string(),
+                        )])),
                         ..Default::default()
                     },
                     ..Default::default()


### PR DESCRIPTION
Adds the `app.kubernetes.io/managed-by` label to resources created by `sessionspaces`. Any thoughts on whether we should add any of the other [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)?