### PR TITLE
Touch `main.rs` after full copy in sessionspaces Dockerfile

### DIFF
--- a/sessionspaces/Dockerfile
+++ b/sessionspaces/Dockerfile
@@ -4,14 +4,15 @@ ARG DATABASE_URL
 
 WORKDIR /app
 
-COPY Cargo.toml Cargo.lock . 
+COPY Cargo.toml Cargo.lock ./
 
 RUN mkdir src && echo "fn main() {}" > src/main.rs \
     && cargo build --release
 
 COPY . .
 
-RUN cargo build --release
+RUN touch src/main.rs \
+    && cargo build --release
 
 FROM gcr.io/distroless/cc-debian12@sha256:e1065a1d58800a7294f74e67c32ec4146d09d6cbe471c1fa7ed456b2d2bf06e0 AS deploy
 


### PR DESCRIPTION
Fixes an issue in which re-compilation of `sessionspaces` in the second `cargo build` was not taking place