### PR TITLE
Update `sessionspaces` namespaces

### DIFF
--- a/sessionspaces/src/resources/config_maps.rs
+++ b/sessionspaces/src/resources/config_maps.rs
@@ -65,10 +65,7 @@ pub async fn create_configmap(
     configmaps
         .patch(
             NAME,
-            &PatchParams {
-                field_manager: Some("kubectl".to_string()),
-                ..Default::default()
-            },
+            &PatchParams::default(),
             &Patch::Apply(&ConfigMap {
                 metadata: ObjectMeta {
                     name: Some(NAME.to_string()),

--- a/sessionspaces/src/resources/config_maps.rs
+++ b/sessionspaces/src/resources/config_maps.rs
@@ -84,6 +84,6 @@ pub async fn create_configmap(
         )
         .await?;
 
-    info!("ConfigMap {NAME} created");
+    info!("{NAME} ConfigMap created / updated for {namespace}");
     Ok(())
 }

--- a/sessionspaces/src/resources/mod.rs
+++ b/sessionspaces/src/resources/mod.rs
@@ -12,3 +12,49 @@ pub use self::{
     config_maps::create_configmap,
     namespace::{create_namespace, delete_namespace},
 };
+use crate::permissionables::Sessions;
+use std::collections::BTreeSet;
+use tracing::{info, instrument};
+
+/// Requests a new bundle from the bundle server and performs templating accordingly
+#[instrument(skip_all, err(level=tracing::Level::WARN))]
+pub async fn update_resources(
+    k8s_client: kube::Client,
+    current_sessions: &Sessions,
+    new_sessions: &Sessions,
+) -> std::result::Result<(), anyhow::Error> {
+    let current_session_names = current_sessions.keys().cloned().collect::<BTreeSet<_>>();
+    let session_names = new_sessions.keys().cloned().collect::<BTreeSet<_>>();
+    let to_update = current_session_names
+        .union(&session_names)
+        .collect::<BTreeSet<_>>();
+
+    info!("Updating {} SessionSpaces", to_update.len());
+    for namespace in to_update.into_iter() {
+        let session_info = new_sessions.get(namespace);
+        let current_sesssion_info = current_sessions.get(namespace);
+        match (current_sesssion_info, session_info) {
+            (Some(_), None) => {
+                info!("Deleting Namespace: {}", namespace);
+                delete_namespace(namespace, k8s_client.clone()).await?;
+            }
+            (None, Some(session_info)) => {
+                info!(
+                    "Creating Namespace, {}, with Config: {}",
+                    namespace, session_info
+                );
+                create_namespace(namespace.clone(), k8s_client.clone()).await?;
+                create_configmap(namespace, session_info.clone(), k8s_client.clone()).await?;
+            }
+            (Some(current_info), Some(session_info)) if current_info != session_info => {
+                info!(
+                    "Updating Namespace, {}, with Config: {}",
+                    namespace, session_info
+                );
+                create_configmap(namespace, session_info.clone(), k8s_client.clone()).await?;
+            }
+            (_, _) => {}
+        }
+    }
+    Ok(())
+}

--- a/sessionspaces/src/resources/namespace.rs
+++ b/sessionspaces/src/resources/namespace.rs
@@ -1,8 +1,9 @@
 use super::{MANAGED_BY, MANAGED_BY_LABEL};
 use k8s_openapi::api::core::v1::Namespace;
+use kube::api::{Patch, PatchParams};
 use kube::Error as KubeError;
 use kube::{
-    api::{DeleteParams, ObjectMeta, PostParams},
+    api::{DeleteParams, ObjectMeta},
     Api,
 };
 use std::collections::BTreeMap;
@@ -35,31 +36,24 @@ pub async fn create_namespace(
     k8s_client: kube::Client,
 ) -> Result<(), kube::Error> {
     let api = Api::<Namespace>::all(k8s_client.clone());
-    match api.get(&namespace.clone()).await {
-        Ok(_) => {
-            info!("Namespace {namespace} already exists, skipping creation");
-            Ok(())
-        }
-        Err(KubeError::Api(api_err)) if api_err.code == 404 => {
-            api.create(
-                &PostParams::default(),
-                &Namespace {
-                    metadata: ObjectMeta {
-                        name: Some(namespace.clone()),
-                        labels: Some(BTreeMap::from([(
-                            MANAGED_BY_LABEL.to_string(),
-                            MANAGED_BY.to_string(),
-                        )])),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            )
-            .await?;
-            Ok(())
-        }
-        Err(e) => Err(e),
-    }
+    api.patch(
+        &namespace,
+        &PatchParams::default(),
+        &Patch::Apply(&Namespace {
+            metadata: ObjectMeta {
+                name: Some(namespace.clone()),
+                labels: Some(BTreeMap::from([(
+                    MANAGED_BY_LABEL.to_string(),
+                    MANAGED_BY.to_string(),
+                )])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    )
+    .await?;
+    info!("Namespace {namespace} created / updated");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -70,90 +64,27 @@ mod tests {
     use mockito::Server;
 
     #[tokio::test]
-    async fn test_create_namespace_existing() {
-        // Create a mock server
+    async fn create_new_namespace() {
         let mut server = Server::new_async().await;
-
-        let m1 = server
-            .mock("GET", "/api/v1/namespaces/test-namespace1")
-            .with_status(200)
-            .with_body(
-                r#"{
-                    "kind": "Namespace",
-                    "apiVersion": "v1",
-                    "metadata": {
-                        "name": "test-namespace1"
-                    }
-                }"#,
-            )
-            .create();
-
-        let m2 = server
-            .mock("GET", "/api/v1/namespaces/test-namespace2")
-            .with_status(200)
-            .with_body(
-                r#"{
-                    "kind": "Namespace",
-                    "apiVersion": "v1",
-                    "metadata": {
-                        "name": "test-namespace2"
-                    }
-                }"#,
-            )
-            .create();
-
-        let config = Config::new(server.url().parse().unwrap());
-        let k8s_client = Client::try_from(config).unwrap();
-
-        assert!(
-            create_namespace("test-namespace1".to_string(), k8s_client.clone())
-                .await
-                .is_ok()
-        );
-        assert!(create_namespace("test-namespace2".to_string(), k8s_client)
-            .await
-            .is_ok());
-
-        // Verify expectations
-        m1.assert();
-        m2.assert();
-    }
-
-    #[tokio::test]
-    async fn test_create_namespace() {
-        // Create a mock server
-        let mut server = Server::new_async().await;
-
-        let m1 = server
-            .mock("POST", "/api/v1/namespaces?")
+        let mock_patch_test_namespace = server
+            .mock("PATCH", "/api/v1/namespaces/test?")
             .with_status(201)
             .with_header("content-type", "application/json")
             .with_body(
                 r#"{
-                    "kind": "Namespace",
                     "apiVersion": "v1",
+                    "kind": "Namespace",
                     "metadata": {
-                        "name": "new-namespace"
+                        "name": "test"
                     }
                 }"#,
             )
             .create();
-
-        let m2 = server
-            .mock("GET", "/api/v1/namespaces/testing-namespace3")
-            .with_status(404)
-            .create();
-
         let config = Config::new(server.url().parse().unwrap());
         let k8s_client = Client::try_from(config).unwrap();
-        assert!(
-            create_namespace("testing-namespace3".to_string(), k8s_client)
-                .await
-                .is_ok()
-        );
-
-        // Verify if the request hits the mock endpoints
-        m1.assert();
-        m2.assert();
+        create_namespace("test".to_string(), k8s_client)
+            .await
+            .unwrap();
+        mock_patch_test_namespace.assert();
     }
 }


### PR DESCRIPTION
Previously we did not update `sessionspaces` namespaces when the session changed, therefore we were left with namespaces without the proper labels, this PR resolves that issue