### PR TITLE
Fix `sessionspaces` chart request rate env var

### DIFF
--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -3,6 +3,6 @@ name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 appVersion: 0.1.0-rc3

--- a/charts/sessionspaces/templates/deployment.yaml
+++ b/charts/sessionspaces/templates/deployment.yaml
@@ -32,6 +32,6 @@ spec:
               value: {{ .Values.ldapUrl }}
             {{- if .Values.requestRate }}
             - name: REQUEST_RATE
-              value: {{ .Values.requestRate | toString }}
+              value: "{{ .Values.requestRate }}"
             {{- end }}
 {{- end -}}


### PR DESCRIPTION
Numeric values were previous rendered as is (e.g. `value: 10`), this ensures they are put in quotes (e.g. `value: "10"`) as required for environment variables