### PR TITLE
Fix `sessionspaces` ldap domain name

### DIFF
--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -3,6 +3,6 @@ name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
 
-version: 0.2.4
+version: 0.2.5
 
 appVersion: 0.1.0-rc3

--- a/charts/sessionspaces/values.yaml
+++ b/charts/sessionspaces/values.yaml
@@ -4,7 +4,7 @@ database:
   password:
     secretName: ispyb
     secretKey: password
-ldapUrl: https://ldap.diamond.ac.uk
+ldapUrl: ldap://ldapmaster.diamond.ac.uk
 requestRate: 10
 
 image:


### PR DESCRIPTION
The DLS ldap is at `ldap://ldapmaster.diamond.ac.uk`, this updates the `sessionspaces` config to point there