### PR TITLE
Deploy app of apps for cluster bootstrapping

### DIFF
--- a/charts/verflixt/Chart.yaml
+++ b/charts/verflixt/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: vxt
+version: 0.1.0

--- a/charts/verflixt/templates/vxt.yaml
+++ b/charts/verflixt/templates/vxt.yaml
@@ -1,0 +1,1 @@
+{{ .Values | toYaml }}

--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.6.0
+version: 0.7.0
 
 dependencies:
   - name: vcluster

--- a/charts/workflows-cluster/dev-values.yaml
+++ b/charts/workflows-cluster/dev-values.yaml
@@ -47,13 +47,100 @@ vcluster:
           release:
             name: argocd
             namespace: argocd
-        - chart:
-            name: argocd-apps
-            version: 0.1.0
-            repo: oci://ghcr.io/diamondlightsource
-          release:
-            name: argocd-apps
+          valuesObject:
+            controller:
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            dex:
+              resources:
+                limits:
+                  cpu: 50m
+                  memory: 512Mi
+                requests:
+                  cpu: 10m
+                  memory: 256Mi
+            redisSecretInit:
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            redis:
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            server:
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            repoServer:
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 250m
+                  memory: 256Mi
+            applicationSet:
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            notifications:
+              resources:
+                limits:
+                  cpu: 50m
+                  memory: 512Mi
+                requests:
+                  cpu: 10m
+                  memory: 256Mi
+        - release:
+            name: verflixt
             namespace: argocd
+          # This is the `charts/verflixt` chart as a packaged base64 string.
+          # You can re-create it with `helm package charts/verflixt && base64 aoa-*.tgz`.
+          # This hack allows us to deploy manifests in a deterministic order, which is not possible using `manifests`.
+          bundle: H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOzVsWrDMBAGYM1+Cj2B8ktRIsjadwh0vEHQgJQYSxYurt+92NCh7uChyKXhvuXAi8/8/Ocy5MPLG3VZvVMMogoAOFu7TADrCZwgtD1bDX10DgLaQENI1Fnnuz5l6gR+/a71x/0T1N6uvku3x/0ii2nuFP1FliE35esplFZo/npPVsfc/0Kh96neAdjsP37031jN/d/DnH/2sQ2UfTqUocZ/YDN/41b5H0/OcP57GEeprkv/5YfMj1eKQU4Tn3vGGHt2nwEAAP//izRyhQAOAAA=
           values: |-
-            dev:
-              enabled: true
+            apiVersion: argoproj.io/v1alpha1
+            kind: Application
+            metadata:
+              name: argocd-apps
+              namespace: argocd
+              annotations:
+                argocd.argoproj.io/sync-wave: "0"
+            spec:
+              destination:
+                namespace: argocd
+                server: https://kubernetes.default.svc
+              project: default
+              source:
+                helm:
+                  parameters:
+                  - name: "dev.enabled"
+                    value: "true"
+                path: charts/argocd-apps
+                repoURL: https://github.com/DiamondLightSource/workflows.git
+                targetRevision: HEAD
+              syncPolicy:
+                automated:
+                  prune: true
+                  selfHeal: true

--- a/charts/workflows-cluster/values.yaml
+++ b/charts/workflows-cluster/values.yaml
@@ -35,20 +35,45 @@ vcluster:
   experimental:
     deploy:
       helm:
-        - chart:
+        - release:
+            name: argocd
+            namespace: argocd
+          chart:
             name: argo-cd
             version: 7.3.0
             repo: https://argoproj.github.io/argo-helm
-          release:
-            name: argocd
+        - release:
+            name: verflixt
             namespace: argocd
-        - chart:
-            name: argocd-apps
-            version: 0.1.0
-            repo: oci://ghcr.io/diamondlightsource
-          release:
-            name: argocd-apps
-            namespace: argocd
+          # This is the `charts/verflixt` chart as a packaged base64 string.
+          # You can re-create it with `helm package charts/verflixt && base64 aoa-*.tgz`.
+          # This hack allows us to deploy manifests in a deterministic order, which is not possible using `manifests`.
+          bundle: H4sIFAAAAAAA/ykAK2FIUjBjSE02THk5NWIzVjBkUzVpWlM5Nk9WVjZNV2xqYW5keVRRbz1IZWxtAOzVsWrDMBAGYM1+Cj2B8ktRIsjadwh0vEHQgJQYSxYurt+92NCh7uChyKXhvuXAi8/8/Ocy5MPLG3VZvVMMogoAOFu7TADrCZwgtD1bDX10DgLaQENI1Fnnuz5l6gR+/a71x/0T1N6uvku3x/0ii2nuFP1FliE35esplFZo/npPVsfc/0Kh96neAdjsP37031jN/d/DnH/2sQ2UfTqUocZ/YDN/41b5H0/OcP57GEeprkv/5YfMj1eKQU4Tn3vGGHt2nwEAAP//izRyhQAOAAA=
+          values: |-
+            apiVersion: argoproj.io/v1alpha1
+            kind: Application
+            metadata:
+              name: argocd-apps
+              namespace: argocd
+              annotations:
+                argocd.argoproj.io/sync-wave: "0"
+            spec:
+              destination:
+                namespace: argocd
+                server: https://kubernetes.default.svc
+              project: default
+              source:
+                helm:
+                  valuesObject:
+                    dev:
+                      enabled: false
+                path: charts/argocd-apps
+                repoURL: https://github.com/DiamondLightSource/workflows.git
+                targetRevision: HEAD
+              syncPolicy:
+                automated:
+                  prune: true
+                  selfHeal: true
   sync:
     toHost:
       ingresses:


### PR DESCRIPTION
An ArgoCD app-of-apps is used to manage the deployment of resources in the virtual cluster. A simple helm chart is used (in it's base64 form) to allow us to deploy these after the deployment of ArgoCD itself