### PR TITLE
Create group ArgoCD projects and apps

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -3,4 +3,4 @@ name: argocd-apps
 description: An argocd app to deploy apps inside the virtual cluster
 type: application
 
-version: 0.2.2
+version: 0.2.3

--- a/charts/argocd-apps/dev-values.yaml
+++ b/charts/argocd-apps/dev-values.yaml
@@ -3,6 +3,9 @@ events:
   extraValuesFiles:
     - dev-values.yaml
 
+groupProjects:
+  enabled: true
+
 kyverno:
   enabled: true
   valuesObject:

--- a/charts/argocd-apps/templates/groups-application.yaml
+++ b/charts/argocd-apps/templates/groups-application.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.groups.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: groups
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  destination:
+    namespace: argocd
+    server: {{ .Values.destination.server }}
+  project: default
+  source:
+    repoURL: https://github.com/DiamondLightSource/workflows.git
+    path: charts/groups
+    targetRevision: {{ .Values.groups.targetRevision }}
+    helm:
+      valueFiles:
+        - values.yaml
+        {{- if .Values.groups.extraValueFiles }}
+        {{- .Values.groups.extraValueFiles | toYaml | nindent 8 }}
+        {{- end }}
+      {{- if .Values.groups.valuesObject }}
+      valuesObject:
+        {{- .Values.groups.valuesObject | toYaml | nindent 8 }}
+      {{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -7,6 +7,12 @@ events:
   extraValuesFiles: []
   valuesObject: {}
 
+groups:
+  enabled: true
+  targetRevision: HEAD
+  extraValuesFiles: []
+  valuesObject: {}
+
 kyverno:
   enabled: true
   targetRevision: 3.2.2

--- a/charts/groups/Chart.yaml
+++ b/charts/groups/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: group-projects
+description: A collection of AppProjects and Apps for science domain groups
+type: application
+
+version: 0.1.0

--- a/charts/groups/templates/applications.yaml
+++ b/charts/groups/templates/applications.yaml
@@ -1,0 +1,27 @@
+{{- range .Values.groups }}
+{{- if .enabled }}
+{{ $group := . }}
+{{- range .apps }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "{{ .name }}-group"
+spec:
+  destination:
+    namespace: "{{ $group.name }}-group"
+    name: {{ $.Values.destination.name }}
+    server: {{ $.Values.destination.server }}
+  project: {{ $group.name }}
+  source:
+    repoURL: {{ .repoURL }}
+    path: {{ .path }}
+    targetRevision: {{ .targetRevision }}
+    directory:
+      recurse: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/groups/templates/namespaces.yaml
+++ b/charts/groups/templates/namespaces.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.groups }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ .name }}-group"
+{{- end }}
+{{- end }}

--- a/charts/groups/templates/projects.yaml
+++ b/charts/groups/templates/projects.yaml
@@ -1,0 +1,32 @@
+{{- range .Values.groups }}
+{{- if .enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {{ .name }}
+spec:
+  description: "WorkflowTemplates for the {{ .name }} group"
+  sourceRepos:
+    {{- if .permittedRepos }}
+    {{ .permittedRepos | toYaml | nindent 4 }}
+    {{- end }}
+    {{- range .apps }}
+    - {{ .repoURL }}
+    {{- end }}
+  destinations:
+    - namespace: "{{ .name }}-group"
+      name: {{ $.Values.destination.name }}
+      server: {{ $.Values.destination.server }}
+  clusterResourceWhitelist:
+    - group: argoproj.io
+      kind: ClusterWorkflowTemplate
+  namespaceResourceWhitelist:
+    - group: argoproj.io
+      kind: WorkflowTemplate
+  roles:
+    - name: member
+      description: "Members of the {{ .name }} group"
+      policies:
+        - "p, proj:{{ .name }}:member, applications, *, {{ .name }}-group/*, allow"
+{{- end }}
+{{- end }}

--- a/charts/groups/values.yaml
+++ b/charts/groups/values.yaml
@@ -1,0 +1,13 @@
+destination:
+  name: in-cluster
+  server: ""
+
+groups:
+  - name: imaging
+    enabled: true
+    permittedRepos: []
+    apps:
+      - name: imaging
+        repoURL: https://github.com/DiamondLightSource/imaging-workflows
+        path: .
+        targetRevision: HEAD


### PR DESCRIPTION
Adds a helm chart which:
- Creates a namespace for each group (with the name `<NAME>-group`)
- Creates an ArgoCD [AppProject](https://argo-cd.readthedocs.io/en/stable/user-guide/projects/) for each group, which can only deploy (Cluster)WorkflowTemplates
- Creates a set of Apps for each group