### PR TITLE
Set kyverno app to a fixed target revision

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -3,4 +3,4 @@ name: argocd-apps
 description: An argocd app to deploy apps inside the virtual cluster
 type: application
 
-version: 0.2.1
+version: 0.2.2

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -9,7 +9,7 @@ events:
 
 kyverno:
   enabled: true
-  targetRevision: HEAD
+  targetRevision: 3.2.2
   extraValuesFiles: []
   valuesObject:
     admissionController:


### PR DESCRIPTION
Looks like we accidentally set this to `HEAD` during all the fixes, this reverts it to `3.2.2`