### PR TITLE
Lookup existing argo workflows postgres secret before generating anew

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.7.5
+version: 0.7.6
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/templates/_helpers.tpl
+++ b/charts/workflows/templates/_helpers.tpl
@@ -1,13 +1,14 @@
 {{/*
 Create a new password for the argo_workflows user in postgres
 */}}
-{{- define "workflows.argoWorkflows.postgresPassword" }}
-  {{- if not .Release.IsUpgrade }}
+{{- define "workflows.argoWorkflowsPostgresPassword" }}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace "postgres-application-passwords") }}
+  {{- if $existing }}
+    {{- index $existing.data "password" | b64dec }}
+  {{- else }}
     {{- if not (index .Release "argoWorkflowsPostgresPassword" ) -}}
       {{- $_ := set .Release "argoWorkflowsPostgresPassword" (randAlphaNum 24) }}
     {{- end }}
     {{- index .Release "argoWorkflowsPostgresPassword" }}
-  {{- else }}
-    {{- index (lookup "v1" "Secret" .Release.Namespace "postgres-application-passwords").data "passwords" | b64dec }}
   {{- end }}
 {{- end }}

--- a/charts/workflows/templates/pgpool-passwords-secret.yaml
+++ b/charts/workflows/templates/pgpool-passwords-secret.yaml
@@ -1,11 +1,12 @@
+{{ $existing := lookup "v1" "Secret" .Release.Namespace "pgpool-passwords" }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: pgpool-passwords
 data:
-  {{- if not .Release.IsUpgrade }}
-  admin-password: {{ randAlphaNum 24 | b64enc }}
+  {{- if $existing }}
+  admin-password: {{ index $existing.data "admin-password" }}
   {{- else }}
-  admin-password: {{ index (lookup "v1" "Secret" .Release.Namespace "pgpool-passwords").data "admin-password" }}
+  admin-password: {{ randAlphaNum 24 | b64enc }}
   {{- end }}
 

--- a/charts/workflows/templates/postgres-application-passwords-secret.yaml
+++ b/charts/workflows/templates/postgres-application-passwords-secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: postgres-application-passwords
 data:
   usernames: {{ print "argo_workflows" | b64enc }}
-  passwords: {{ include "workflows.argoWorkflows.postgresPassword" . | b64enc }}
+  passwords: {{ include "workflows.argoWorkflowsPostgresPassword" . | b64enc }}
 

--- a/charts/workflows/templates/postgres-initdb-script-secret.yaml
+++ b/charts/workflows/templates/postgres-initdb-script-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: postgres-initdb-script
 data:
-  init.sql: {{ printf "CREATE USER argo_workflows WITH PASSWORD '%s';\nCREATE DATABASE argo_workflows OWNER argo_workflows;" (include "workflows.argoWorkflows.postgresPassword" .) | b64enc }}
+  init.sql: {{ printf "CREATE USER argo_workflows WITH PASSWORD '%s';\nCREATE DATABASE argo_workflows OWNER argo_workflows;" (include "workflows.argoWorkflowsPostgresPassword" .) | b64enc }}
 

--- a/charts/workflows/templates/postgres-passwords-secret.yaml
+++ b/charts/workflows/templates/postgres-passwords-secret.yaml
@@ -1,13 +1,14 @@
+{{ $existing := lookup "v1" "Secret" .Release.Namespace "postgres-passwords" }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: postgres-passwords
 data:
-  {{- if not .Release.IsUpgrade }}
+  {{- if $existing }}
+  password: {{ index $existing.data "password" }}
+  repmgr-password: {{ index $existing.data "repmgr-password" }}
+  {{- else }}
   password: {{ randAlphaNum 24 | b64enc }}
   repmgr-password: {{ randAlphaNum 24 | b64enc }}
-  {{- else }}
-  password: {{ index (lookup "v1" "Secret" .Release.Namespace "postgres-passwords").data "password" }}
-  repmgr-password: {{ index (lookup "v1" "Secret" .Release.Namespace "postgres-passwords").data "repmgr-password" }}
   {{- end }}
 


### PR DESCRIPTION
Checks for the existence of a argo workflows postgres passwords secret instead of relying on the helm `.Release.isUpgrade` value to determine whether a new password should be generated. This should resolve the issue in which the Argo Workflows server gets a new password but the one in the database remains