### PR TITLE
Add documnent separator to groups templates

### DIFF
--- a/charts/groups/Chart.yaml
+++ b/charts/groups/Chart.yaml
@@ -3,4 +3,4 @@ name: group-projects
 description: A collection of AppProjects and Apps for science domain groups
 type: application
 
-version: 0.1.1
+version: 0.1.2

--- a/charts/groups/templates/applications.yaml
+++ b/charts/groups/templates/applications.yaml
@@ -22,6 +22,7 @@ spec:
     automated:
       prune: true
       selfHeal: true
+---
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/groups/templates/namespaces.yaml
+++ b/charts/groups/templates/namespaces.yaml
@@ -4,5 +4,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "{{ .name }}-group"
+---
 {{- end }}
 {{- end }}

--- a/charts/groups/templates/projects.yaml
+++ b/charts/groups/templates/projects.yaml
@@ -28,5 +28,6 @@ spec:
       description: "Members of the {{ .name }} group"
       policies:
         - "p, proj:{{ .name }}:member, applications, *, {{ .name }}-group/*, allow"
+---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The missing document separator meant only the last of each template was actually applied