### PR TITLE
Create policy to apply podCG to Workflows and Workflow Templates

### DIFF
--- a/.github/workflows/kyverno-policy.yaml
+++ b/.github/workflows/kyverno-policy.yaml
@@ -30,10 +30,18 @@ jobs:
           helm repo update
           helm dep build charts/workflows
 
-      - name: Install Kyvenro and wait for CRDs
+      - name: Install Kyvenro
         run: |
           helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace --set cleanupController.enabled=false --set reportsController.enabled=false
-          helm get manifest --namespace kyverno kyverno | yq e '. | select(.kind == "CustomResourceDefinition")' | kubectl wait --for=condition=Established --timeout=60s -f -
+          helm get manifest --namespace kyverno kyverno | yq e '. | select(.kind == "CustomResourceDefinition")' > /tmp/crds.yaml
+
+      - name: Install Workflows CRDs
+        run: |
+          helm template workflows charts/workflows --namespace workflows --create-namespace | yq e 'select(.kind == "CustomResourceDefinition")' | tee -a /tmp/crds.yaml | kubectl apply -f -
+
+      - name: Wait for CRDs
+        run: |
+         cat /tmp/crds.yaml | kubectl wait --for=condition=Established --timeout=60s -f -
 
       - name: Deploy and wait for Policies, ClusterRoles, and ClusterRoleBindings
         run: |

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.7.10
+version: 0.7.11
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/templates/sessionspace-clusterpolicy.yaml
+++ b/charts/workflows/templates/sessionspace-clusterpolicy.yaml
@@ -45,6 +45,17 @@ spec:
                         name: "!artifact-s3"
                 =(volumeMounts):
                   - name: "!artifact-s3"
+    - name: apply-default-pod-gc
+      match:
+        resources:
+          kinds:
+            - argoproj.io/*/Workflow
+      mutate:
+        patchStrategicMerge:
+          spec:
+            +(podGC):
+              +(strategy): OnPodCompletion
+              +(deleteDelayDuration): 60s
     - name: copy-artifact-s3-secret
       match:
         resources:

--- a/charts/workflows/test-policy/workflow-pod-gc/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/workflow-pod-gc/chainsaw-test.yaml
@@ -1,0 +1,45 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: workflow-gc
+spec:
+  steps:
+    - try:
+        - apply:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: no-gc-workflow
+              spec: {}
+        - assert:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: no-gc-workflow
+              spec:
+                podGC:
+                  strategy: OnPodCompletion
+                  deleteDelayDuration: 60s
+    - try:
+        - apply:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: gc-workflow
+              spec:
+                podGC:
+                  strategy: OnWorkflowCompletion
+                  deleteDelayDuration: 30s
+        - assert:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: gc-workflow
+              spec:
+                podGC:
+                  strategy: OnWorkflowCompletion
+                  deleteDelayDuration: 30s


### PR DESCRIPTION
Requires #106 & #114

Sets up a default [Pod Garbage Collection](https://argo-workflows.readthedocs.io/en/stable/cost-optimisation/#limit-the-total-number-of-workflows-and-pods) (`podGC`) strategy to ensure completed pods are removed from the cluster. What are your thoughts on applying to `WorkflowTemplates` and `ClusterWorkflowTemplates` in addition to `Workflows`?