### PR TITLE
Use namespace templating in chainsaw tests

### DIFF
--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -3,6 +3,6 @@ name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
 
-version: 0.2.9
+version: 0.2.10
 
 appVersion: 0.1.0-rc13

--- a/charts/sessionspaces/test-policy/pod-hostpath/chainsaw-test.yaml
+++ b/charts/sessionspaces/test-policy/pod-hostpath/chainsaw-test.yaml
@@ -3,55 +3,48 @@ kind: Test
 metadata:
   name: hostpath
 spec:
+  namespaceTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: sessionspaces
   steps:
-  - try:
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: test-hostpath
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: sessionspaces
-            namespace: test-hostpath
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-          data:
-            data_directory: "/allowed/path"
-            gid: "1234"
-    - create:
-        resource:
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: allowed
-            namespace: test-hostpath
-          spec:
-            containers:
-            - name: nginx
-              image: nginx:latest
-            volumes:
-            - name: test-volume
-              hostPath:
-                path: "/allowed/path"
-    - error:
-        resource:
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: disallowed
-            namespace: test-hostpath
-          spec:
-            containers:
-            - name: nginx
-              image: nginx:latest
-            volumes:
-            - name: test-volume
-              hostPath:
-                path: "/disallowed/path"
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: sessionspaces
+                labels:
+                  app.kubernetes.io/managed-by: sessionspaces
+              data:
+                data_directory: "/allowed/path"
+                gid: "1234"
+        - create:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: allowed
+              spec:
+                containers:
+                - name: nginx
+                  image: nginx:latest
+                volumes:
+                - name: test-volume
+                  hostPath:
+                    path: "/allowed/path"
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: disallowed
+              spec:
+                containers:
+                - name: nginx
+                  image: nginx:latest
+                volumes:
+                - name: test-volume
+                  hostPath:
+                    path: "/disallowed/path"

--- a/charts/sessionspaces/test-policy/pod-securitycontext/chainsaw-test.yaml
+++ b/charts/sessionspaces/test-policy/pod-securitycontext/chainsaw-test.yaml
@@ -3,66 +3,59 @@ kind: Test
 metadata:
   name: pod-securitycontext
 spec:
+  namespaceTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: sessionspaces
   steps:
-  - try:
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: sessionspace
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: sessionspaces
-            namespace: sessionspace
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-          data:
-            data_directory: "/allowed/path"
-            gid: "1234"
-    - create:
-        resource:
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: test-pod
-            namespace: sessionspace
-          spec:
-            containers:
-              - name: test-container
-                image: docker.io/library/busybox:latest
-            initContainers:
-              - name: test-init-container
-                image: docker.io/library/busybox:latest
-    - assert:
-        resource:
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: test-pod
-            namespace: sessionspace
-          spec:
-            securityContext:
-              runAsGroup: 1234
-              runAsUser: 36055
-            containers:
-              - name: test-container
-                image: docker.io/library/busybox:latest
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: sessionspaces
+                labels:
+                  app.kubernetes.io/managed-by: sessionspaces
+              data:
+                data_directory: "/allowed/path"
+                gid: "1234"
+        - create:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-pod
+              spec:
+                containers:
+                  - name: test-container
+                    image: docker.io/library/busybox:latest
+                initContainers:
+                  - name: test-init-container
+                    image: docker.io/library/busybox:latest
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-pod
+              spec:
                 securityContext:
                   runAsGroup: 1234
                   runAsUser: 36055
-                  allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-            initContainers:
-              - name: test-init-container
-                image: docker.io/library/busybox:latest
-                securityContext:
-                  runAsGroup: 1234
-                  runAsUser: 36055
-                  allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
+                containers:
+                  - name: test-container
+                    image: docker.io/library/busybox:latest
+                    securityContext:
+                      runAsGroup: 1234
+                      runAsUser: 36055
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                initContainers:
+                  - name: test-init-container
+                    image: docker.io/library/busybox:latest
+                    securityContext:
+                      runAsGroup: 1234
+                      runAsUser: 36055
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.7.7
+version: 0.7.8
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
@@ -3,38 +3,31 @@ kind: Test
 metadata:
   name: argo-workflow
 spec:
+  namespaceTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: sessionspaces
   steps:
-  - try:
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: test-argo-workflow
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: sessionspaces
-            namespace: test-argo-workflow
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-          data:
-            members: '["member1", "member2"]'
-    - assert:
-        resource:
-          apiVersion: v1
-          kind: ServiceAccount
-          metadata:
-            name: argo-workflow
-            namespace: test-argo-workflow
-    - assert:
-        resource:
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: RoleBinding
-          metadata:
-            name: argo-workflow
-            namespace: test-argo-workflow
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: sessionspaces
+                labels:
+                  app.kubernetes.io/managed-by: sessionspaces
+              data:
+                members: '["member1", "member2"]'
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: argo-workflow
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: argo-workflow

--- a/charts/workflows/test-policy/visit-member/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/visit-member/chainsaw-test.yaml
@@ -3,38 +3,31 @@ kind: Test
 metadata:
   name: visit-members
 spec:
+  namespaceTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: sessionspaces
   steps:
-  - try:
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: test-visit-member
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-    - apply:
-        resource:
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: sessionspaces
-            namespace: test-visit-member
-            labels:
-              app.kubernetes.io/managed-by: sessionspaces
-          data:
-            members: '["member1", "member2"]'
-    - assert:
-        resource:
-          apiVersion: v1
-          kind: ServiceAccount
-          metadata:
-            name: visit-member
-            namespace: test-visit-member
-    - assert:
-        resource:
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: RoleBinding
-          metadata:
-            name: visit-member
-            namespace: test-visit-member
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: sessionspaces
+                labels:
+                  app.kubernetes.io/managed-by: sessionspaces
+              data:
+                members: '["member1", "member2"]'
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: visit-member
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: visit-member


### PR DESCRIPTION
Resolves some race conditions which arose from reusing the `session` Namespace across chainsaw tests which are run in parallel