### PR TITLE
Configure `yaml` and `tpl` files to be detected by linguist as `yaml`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
+*.yaml linguist-detectable
+*.tpl linguist-detectable linguist-language=yaml


### PR DESCRIPTION
[Overrides](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md) default `linguist` configuration to have `.yaml` and `.tpl` files registered as `yaml`. Unfortunately linguist doesn't recognise Helm as a language so this seems best