### PR TITLE
Increase wait duration of tests with cascading generation

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.7.11
+version: 0.7.12
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
               data:
                 members: '["member1", "member2"]'
         - sleep:
-            duration: 5s
+            duration: 10s
         - assert:
             resource:
               apiVersion: v1

--- a/charts/workflows/test-policy/visit-member/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/visit-member/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
               data:
                 members: '["member1", "member2"]'
         - sleep:
-            duration: 5s
+            duration: 10s
         - assert:
             resource:
               apiVersion: v1


### PR DESCRIPTION
We've seen a few instances of the `argo-workflow` and `visit-member` test fail on the latter assertions without clear reason, this is likely because the generate requests used to create them cascade leading to a longer than anticipated delay in creation