### PR TITLE
Skip oauth2 proxy for /assets

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.8.1
+version: 0.8.2
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -84,6 +84,7 @@ oauth2-proxy:
       skip_auth_routes = [
         "OPTIONS=^/$",
         "GET=^/api/"
+        "GET=^/assets/"
       ]
   alphaConfig:
     enabled: true


### PR DESCRIPTION
These aren't a protected resource and don't require a bearer token