### PR TITLE
Skip oauth2 proxy for `/assets`

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.8.2
+version: 0.8.3
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -83,7 +83,7 @@ oauth2-proxy:
       ]
       skip_auth_routes = [
         "OPTIONS=^/$",
-        "GET=^/api/"
+        "GET=^/api/",
         "GET=^/assets/"
       ]
   alphaConfig:


### PR DESCRIPTION
The previous PR (#145) had a syntax error (a missing comma) in the config