### PR TITLE
Group rust opentelemety dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,6 +32,10 @@ updates:
         patterns:
           - kube
           - k8s-openapi
+      opentelemetry:
+        patterns:
+          - opentelemetry*
+          - tracing-opentelemetry
       patch:
         update-types:
           - patch


### PR DESCRIPTION
A lot of these are closely coupled when it comes to versions, easier to just group them