### PR TITLE
fix argo workflow API schema

### DIFF
--- a/graph-proxy/argo-workflows-openapi/build.rs
+++ b/graph-proxy/argo-workflows-openapi/build.rs
@@ -1,4 +1,5 @@
 use quote::quote;
+use schemars::schema::{InstanceType, RootSchema, Schema, SchemaObject};
 use std::{
     env,
     fs::{create_dir_all, File},
@@ -12,7 +13,25 @@ fn main() {
         .unwrap()
         .text()
         .unwrap();
-    let schema = serde_json::from_str::<schemars::schema::RootSchema>(&raw_schema).unwrap();
+    let mut schema: RootSchema = serde_json::from_str(&raw_schema).unwrap();
+    // The upstream argo workflow API schema does not match with its API response.
+    // This is a temporary fix to match the API response.
+    if let Some(Schema::Object(ref mut pod_gc)) = schema
+        .definitions
+        .get_mut("io.argoproj.workflow.v1alpha1.PodGC")
+    {
+        let delete_delay_duration = pod_gc
+            .object
+            .as_mut()
+            .unwrap()
+            .properties
+            .get_mut("deleteDelayDuration")
+            .unwrap();
+        *delete_delay_duration = Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            ..Default::default()
+        });
+    }
 
     let mut type_space = TypeSpace::new(TypeSpaceSettings::default().with_struct_builder(true));
     type_space.add_root_schema(schema).unwrap();


### PR DESCRIPTION
The argo workflows API schema does not match with its API response. This is a temporary fix to the schema. 