### PR TITLE
Run workflows with POSIX uid

### DIFF
--- a/.github/workflows/_kyverno_policy.yaml
+++ b/.github/workflows/_kyverno_policy.yaml
@@ -29,7 +29,7 @@ jobs:
           helm dep build charts/workflows
           helm dep build charts/sessionspaces
 
-      - name: Install Kyvenro
+      - name: Install Kyverno
         run: |
           helm install kyverno kyverno/kyverno --version 3.2.6 --namespace kyverno --create-namespace --set cleanupController.enabled=false --set reportsController.enabled=false
           helm get manifest --namespace kyverno kyverno | yq e '. | select(.kind == "CustomResourceDefinition")' > /tmp/crds.yaml

--- a/.github/workflows/_kyverno_policy.yaml
+++ b/.github/workflows/_kyverno_policy.yaml
@@ -45,7 +45,10 @@ jobs:
       - name: Deploy and wait for Policies, ClusterRoles, and ClusterRoleBindings
         run: |
           helm template sessionspaces charts/sessionspaces | yq e '. | select(.kind == "Policy" or .kind == "ClusterPolicy" or .kind == "ClusterRole" or .kind == "ClusterRoleBinding")' | tee -a /tmp/policies.yaml | kubectl apply -f -
-          helm template workflows charts/workflows | yq e '. | select(.kind == "Policy" or .kind == "ClusterPolicy" or .kind == "ClusterRole" or .kind == "ClusterRoleBinding")' | tee -a /tmp/policies.yaml | kubectl apply -f -
+          # NOTE: workflows-posix-uid-label policy has been excluded from chainsaw testing
+          # To make testing work with this policy in place, it will be required to emulate the existence
+          # of a POSIX uid label as part of request.userInfo.extra
+          helm template workflows charts/workflows | yq e '. | select(.kind == "Policy" or .kind == "ClusterPolicy" or .kind == "ClusterRole" or .kind == "ClusterRoleBinding") | select(.metadata.name != "workflows-posix-uid-label")' | tee -a /tmp/policies.yaml | kubectl apply -f -
           cat /tmp/policies.yaml | yq e '. | select(.kind == "Policy" or .kind == "ClusterPolicy")' | kubectl wait --for=condition=Ready --timeout=60s -f -
 
       - name: Wait for Kyverno

--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
-version: 0.3.4
+
+version: 0.3.5
 appVersion: 0.1.0-rc25
 dependencies:
   - name: common

--- a/charts/sessionspaces/templates/pod-clusterpolicy.yaml
+++ b/charts/sessionspaces/templates/pod-clusterpolicy.yaml
@@ -16,35 +16,45 @@ spec:
             matchLabels:
               app.kubernetes.io/managed-by: sessionspaces
       context:
+        - name: namespace
+          variable:
+            value: "{{ `{{request.object.metadata.namespace}}` }}"
+        - name: workflow
+          variable:
+            jmesPath: request.object.metadata.ownerReferences[0].name
+        - name: uid
+          apiCall:
+            urlPath: /apis/argoproj.io/v1alpha1/namespaces/{{ `{{ namespace }}` }}/workflows/{{ `{{ workflow }}` }}
+            jmesPath: 'metadata.labels | "workflows.diamond.ac.uk/creator-posix-uid"'
         - name: values
           configMap:
             name: sessionspaces
-            namespace: "{{ `{{request.object.metadata.namespace}}` }}"
+            namespace: "{{ `{{ namespace }}` }}"
       mutate:
         patchStrategicMerge:
           spec:
             securityContext:
               runAsGroup: "{{ `{{values.data.gid | parse_json(@).to_number(@)}}` }}"
-              runAsUser: {{ $.Values.policy.runAsUser }}
+              runAsUser: "{{ `{{ uid | parse_json(@).to_number(@) }}` }}"
             containers:
               - (name): "*"
                 securityContext:
                   runAsGroup: "{{ `{{values.data.gid | parse_json(@).to_number(@)}}` }}"
-                  runAsUser: {{ $.Values.policy.runAsUser }}
+                  runAsUser: "{{ `{{ uid | parse_json(@).to_number(@) }}` }}"
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
             initContainers:
               - (name): "*"
                 securityContext:
                   runAsGroup: "{{ `{{values.data.gid | parse_json(@).to_number(@)}}` }}"
-                  runAsUser: {{ $.Values.policy.runAsUser }}
+                  runAsUser: "{{ `{{ uid | parse_json(@).to_number(@) }}` }}"
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
             ephemeralContainers:
               - (name): "*"
                 securityContext:
                   runAsGroup: "{{ `{{values.data.gid | parse_json(@).to_number(@)}}` }}"
-                  runAsUser: {{ $.Values.policy.runAsUser }}
+                  runAsUser: "{{ `{{ uid | parse_json(@).to_number(@) }}` }}"
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true
     - name: check-hostpath

--- a/charts/sessionspaces/test-policy/pod-hostpath/chainsaw-test.yaml
+++ b/charts/sessionspaces/test-policy/pod-hostpath/chainsaw-test.yaml
@@ -20,12 +20,26 @@ spec:
               data:
                 data_directory: "/allowed/path"
                 gid: "1234"
+        - apply:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: test-workflow
+                labels:
+                  workflows.diamond.ac.uk/creator-posix-uid: "12345"
+              spec: {}
         - create:
             resource:
               apiVersion: v1
               kind: Pod
               metadata:
                 name: allowed
+                ownerReferences:
+                  - name: test-workflow
+                    kind: Workflow
+                    apiVersion: argoproj.io/v1alpha1
+                    uid: abc1234
               spec:
                 containers:
                 - name: nginx

--- a/charts/sessionspaces/test-policy/pod-securitycontext/chainsaw-test.yaml
+++ b/charts/sessionspaces/test-policy/pod-securitycontext/chainsaw-test.yaml
@@ -12,12 +12,6 @@ spec:
         - create:
             resource:
               apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: myspace
-        - create:
-            resource:
-              apiVersion: v1
               kind: ConfigMap
               metadata:
                 name: sessionspaces
@@ -32,25 +26,34 @@ spec:
               kind: Workflow
               metadata:
                 name: test-workflow
-                namespace: myspace
-                uid: abc1234
                 labels:
                   workflows.diamond.ac.uk/creator-posix-uid: "4321"
               spec: {}
-        - sleep:
-            duration: 10s
+        - command:
+            env:
+              - name: namespace
+                value: ($namespace)
+            entrypoint: kubectl
+            args:
+              - get
+              - workflow
+              - test-workflow
+              - --namespace=$namespace
+              - --output=jsonpath={.metadata.uid}
+            outputs:
+              - name: workflow_uid
+                value: ($stdout)
         - create:
             resource:
               apiVersion: v1
               kind: Pod
               metadata:
                 name: test-pod
-                namespace: myspace
                 ownerReferences:
                   - name: test-workflow
                     kind: Workflow
                     apiVersion: argoproj.io/v1alpha1
-                    uid: abc1234
+                    uid: ($workflow_uid)
               spec:
                 containers:
                   - name: test-container
@@ -64,50 +67,23 @@ spec:
               kind: Pod
               metadata:
                 name: test-pod
-                namespace: myspace
-                ownerReferences:
-                  - name: test-workflow
-                    kind: Workflow
-                    apiVersion: argoproj.io/v1alpha1
-                    uid: abc1234
-              spec:
-                containers:
-                  - name: test-container
-                    image: docker.io/library/busybox:latest
-                initContainers:
-                  - name: test-init-container
-                    image: docker.io/library/busybox:latest
-        - sleep:
-            duration: 60s
-        - assert:
-            resource:
-              apiVersion: v1
-              kind: Pod
-              metadata:
-                name: test-pod
-                namespace: myspace
-                ownerReferences:
-                  - name: test-workflow
-                    kind: Workflow
-                    apiVersion: argoproj.io/v1alpha1
-                    uid: abc1234
               spec:
                 securityContext:
                   runAsGroup: 1234
-                #   runAsUser: 36055
+                  runAsUser: 4321
                 containers:
                   - name: test-container
                     image: docker.io/library/busybox:latest
                     securityContext:
                       runAsGroup: 1234
-                    #   runAsUser: 36055
-                    #   allowPrivilegeEscalation: false
-                    #   readOnlyRootFilesystem: true
+                      runAsUser: 4321
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
                 initContainers:
                   - name: test-init-container
                     image: docker.io/library/busybox:latest
                     securityContext:
                       runAsGroup: 1234
-                    #   runAsUser: 36055
-                    #   allowPrivilegeEscalation: false
-                    #   readOnlyRootFilesystem: true
+                      runAsUser: 4321
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true

--- a/charts/sessionspaces/test-policy/pod-securitycontext/chainsaw-test.yaml
+++ b/charts/sessionspaces/test-policy/pod-securitycontext/chainsaw-test.yaml
@@ -9,7 +9,13 @@ spec:
         app.kubernetes.io/managed-by: sessionspaces
   steps:
     - try:
-        - apply:
+        - create:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: myspace
+        - create:
             resource:
               apiVersion: v1
               kind: ConfigMap
@@ -22,10 +28,29 @@ spec:
                 gid: "1234"
         - create:
             resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: test-workflow
+                namespace: myspace
+                uid: abc1234
+                labels:
+                  workflows.diamond.ac.uk/creator-posix-uid: "4321"
+              spec: {}
+        - sleep:
+            duration: 10s
+        - create:
+            resource:
               apiVersion: v1
               kind: Pod
               metadata:
                 name: test-pod
+                namespace: myspace
+                ownerReferences:
+                  - name: test-workflow
+                    kind: Workflow
+                    apiVersion: argoproj.io/v1alpha1
+                    uid: abc1234
               spec:
                 containers:
                   - name: test-container
@@ -39,23 +64,50 @@ spec:
               kind: Pod
               metadata:
                 name: test-pod
+                namespace: myspace
+                ownerReferences:
+                  - name: test-workflow
+                    kind: Workflow
+                    apiVersion: argoproj.io/v1alpha1
+                    uid: abc1234
+              spec:
+                containers:
+                  - name: test-container
+                    image: docker.io/library/busybox:latest
+                initContainers:
+                  - name: test-init-container
+                    image: docker.io/library/busybox:latest
+        - sleep:
+            duration: 60s
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-pod
+                namespace: myspace
+                ownerReferences:
+                  - name: test-workflow
+                    kind: Workflow
+                    apiVersion: argoproj.io/v1alpha1
+                    uid: abc1234
               spec:
                 securityContext:
                   runAsGroup: 1234
-                  runAsUser: 36055
+                #   runAsUser: 36055
                 containers:
                   - name: test-container
                     image: docker.io/library/busybox:latest
                     securityContext:
                       runAsGroup: 1234
-                      runAsUser: 36055
-                      allowPrivilegeEscalation: false
-                      readOnlyRootFilesystem: true
+                    #   runAsUser: 36055
+                    #   allowPrivilegeEscalation: false
+                    #   readOnlyRootFilesystem: true
                 initContainers:
                   - name: test-init-container
                     image: docker.io/library/busybox:latest
                     securityContext:
                       runAsGroup: 1234
-                      runAsUser: 36055
-                      allowPrivilegeEscalation: false
-                      readOnlyRootFilesystem: true
+                    #   runAsUser: 36055
+                    #   allowPrivilegeEscalation: false
+                    #   readOnlyRootFilesystem: true

--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.8.6
+version: 0.9.0
 
 dependencies:
   - name: common

--- a/charts/workflows-cluster/values.yaml
+++ b/charts/workflows-cluster/values.yaml
@@ -133,6 +133,9 @@ authenticationConfiguration:
           prefix: "oidc:"
         uid:
           claim: fedid
+        extra:
+        - key: 'workflows.diamond.ac.uk/posixuid'
+          valueExpression: 'string(claims.posix_uid)'
       userValidationRules:
       - expression: "!user.username.startsWith('system:')"
         message: 'username cannot use reserved system: prefix'

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.12.3
+version: 0.13.0
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/templates/workflow-label-clusterpolicy.yaml
+++ b/charts/workflows/templates/workflow-label-clusterpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ .Release.Name }}-posix-uid-label
+spec:
+  background: false
+  validationFailureAction: Enforce
+  rules:
+    - name: apply-posix-uid-label
+      match:
+        resources:
+          kinds:
+            - argoproj.io/*/Workflow
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra | "workflows.diamond.ac.uk/posixuid" | [0] }}` }}'

--- a/charts/workflows/test-policy/artifact-s3-usage/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/artifact-s3-usage/chainsaw-test.yaml
@@ -29,12 +29,26 @@ spec:
               data:
                 data_directory: "/allowed/path"
                 gid: "1234"
+        - apply:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                name: test-workflow
+                labels:
+                  workflows.diamond.ac.uk/creator-posix-uid: "12345"
+              spec: {}
         - create:
             resource:
               apiVersion: v1
               kind: Pod
               metadata:
                 name: allowed
+                ownerReferences:
+                  - name: test-workflow
+                    kind: Workflow
+                    apiVersion: argoproj.io/v1alpha1
+                    uid: abc1234
               spec:
                 initContainers:
                   - name: init

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -126,7 +126,7 @@ oauth2-proxy:
             - claim: id_token
       providers:
         - provider: oidc
-          scope: "openid profile email fedid"
+          scope: "openid posix-uid profile email fedid"
           clientId: workflows-argo-server
           clientSecretFile: /etc/alpha/secret
           id: authn


### PR DESCRIPTION
- [x] Mutate pod in sessionspaces to fetch `posix-uid` label from workflow and set `runAsUser` in security context
- [x] Add policy that adds hard-coded `posix-uid` label to a Workflow
- [x] Modify claimMappings in the workflows-cluster to include `uidNumber` and replace hard-coded `posix-uid` label