### PR TITLE
Generate Workflow Template arguments JSON Schema from manifest

### DIFF
--- a/docs/explanations/parameter-schema-annotations.md
+++ b/docs/explanations/parameter-schema-annotations.md
@@ -1,0 +1,9 @@
+# Parameter Schema Annotations
+
+!!! note
+
+    See also [UI Schema Annotations](./ui-schema-annotation.md)
+
+On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) annotations prefixed with `workflows.diamond.ac.uk/paramter-schema` annotations with dot seperated subpaths of the step to which the parameter belongs and the parameter name (e.g. `metadata.annotations."workflows.diamond.ac.uk/parameter-schema.numpy-test.num-cores"`) are reserved for the specification of parameter [JSON Schema](https://json-schema.org/).
+
+The Schema is used to enhance type checking in the `WorkflowTemplate` and `ClusterWorkflowTemplate` submission forms. If no Schema is supplied one will be automatically generated in which parameters will be assumed to be of type `String` or `Enum` depending on whether they contain the `enum` declaration.

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -11,42 +11,42 @@ metadata:
 spec:
   entrypoint: numpy-test
   templates:
-  - name: numpy-test
-    inputs:
-      parameters:
-      - name: size
-        value: 2000
-      - name: memory
-        value: 20Gi
-    script:
-      image: gcr.io/diamond-privreg/ptypy/test_openmpi_full:0.1
-      command: ["python"]
-      env:
-      - name: MKL_NUM_THREADS
-        value: "1"
-      - name: NUMEXPR_NUM_THREADS
-        value: "1"
-      - name: OMP_NUM_THREADS
-        value: "1"
-      source: |
-        import numpy as np
-        import time
+    - name: numpy-test
+      inputs:
+        parameters:
+          - name: size
+            value: 2000
+          - name: memory
+            value: 20Gi
+      script:
+        image: gcr.io/diamond-privreg/ptypy/test_openmpi_full:0.1
+        command: ["python"]
+        env:
+          - name: MKL_NUM_THREADS
+            value: "1"
+          - name: NUMEXPR_NUM_THREADS
+            value: "1"
+          - name: OMP_NUM_THREADS
+            value: "1"
+        source: |
+          import numpy as np
+          import time
 
-        n = int("{{ inputs.parameters.size }}")
-        A = np.random.randn(n,n).astype('float64')
-        B = np.random.randn(n,n).astype('float64')
-        start_time = time.time()
-        nrm = np.linalg.norm(A@B)
-        print(" took {} seconds ".format(time.time() - start_time))
-        print(" norm = ",nrm)
-        print(np.__config__.show())
-    podSpecPatch: |
-      containers:
-      - name: main
-        resources:
-          requests:
-            cpu: "1"
-            memory: "{{ inputs.parameters.memory }}"
-          limits:
-            cpu: "1"
-            memory: "{{ inputs.parameters.memory }}"
+          n = int("{{ inputs.parameters.size }}")
+          A = np.random.randn(n,n).astype('float64')
+          B = np.random.randn(n,n).astype('float64')
+          start_time = time.time()
+          nrm = np.linalg.norm(A@B)
+          print(" took {} seconds ".format(time.time() - start_time))
+          print(" norm = ",nrm)
+          print(np.__config__.show())
+      podSpecPatch: |
+        containers:
+        - name: main
+          resources:
+            requests:
+              cpu: "1"
+              memory: "{{ inputs.parameters.memory }}"
+            limits:
+              cpu: "1"
+              memory: "{{ inputs.parameters.memory }}"

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -8,6 +8,10 @@ metadata:
       Runs a numpy script in a python container.
       The script finds the normal of the dot product of two random matrices.
       Matrix sizes are specified by the input parameter "size".
+    workflows.diamond.ac.uk/parameter-schema.numpy-test.size: |
+      { "type": "integer", "default": 2000 }
+    workflows.diamond.ac.uk/parameter-schema.numpy-test.memory: |
+      { "type": "string", "pattern": "^[0-9]+[GMK]i$", "default": "20Gi" }
 spec:
   entrypoint: numpy-test
   templates:

--- a/graph-proxy/Cargo.lock
+++ b/graph-proxy/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "opentelemetry_sdk",
  "reqwest",
  "schemars",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/graph-proxy/Cargo.lock
+++ b/graph-proxy/Cargo.lock
@@ -872,6 +872,8 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -1887,18 +1889,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2081,9 +2083,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2548,9 +2550,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"

--- a/graph-proxy/Cargo.toml
+++ b/graph-proxy/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { version = "0.12.8", default-features = false, features = [
     "json",
 ] }
 schemars = "0.8.21"
+serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 thiserror = { version = "1.0.64" }
 tokio = { version = "1.40.0", features = ["macros", "net", "rt-multi-thread"] }

--- a/graph-proxy/Cargo.toml
+++ b/graph-proxy/Cargo.toml
@@ -23,6 +23,8 @@ reqwest = { version = "0.12.8", default-features = false, features = [
     "rustls-tls",
     "json",
 ] }
+schemars = "0.8.21"
+serde_json = "1.0.128"
 thiserror = { version = "1.0.64" }
 tokio = { version = "1.40.0", features = ["macros", "net", "rt-multi-thread"] }
 tracing = { version = "0.1.40" }

--- a/graph-proxy/src/graphql/workflow_templates.rs
+++ b/graph-proxy/src/graphql/workflow_templates.rs
@@ -13,7 +13,7 @@ use tracing::{debug, instrument};
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::missing_docs_in_private_items)]
 enum WorkflowTemplateParsingError {
-    #[error(r#"metadata.labels."argocd.argoproj.io/instance" was expectd but was not present"#)]
+    #[error(r#"metadata.labels."argocd.argoproj.io/instance" was expected but was not present"#)]
     MissingInstanceLabel,
 }
 


### PR DESCRIPTION
Adds generation of JSON Schema for Workflow Template arguments, following the assumptions:
- All parameters are of type `String`
- Parameters are free-form unless a list of `enum` values are provided, in which case they should be a `String enum`
- Top level parameters are required
- Entrypoint parameters are required

~~Currently unsure if we need to present options for non-entrypoint arguments :shrug:~~
Looks like we're going to have to support [intermediate parameters](https://argo-workflows.readthedocs.io/en/latest/intermediate-inputs/) down the line

**Example Query:**
```graphql
query {
  workflowTemplate(name: "numpy-benchmark") {
    name,
    maintainer,
    description,
    arguments
  }
}
```

**Example Response:**
```json
{
  "data": {
    "workflowTemplate": {
      "name": "numpy-benchmark",
      "maintainer": "examples-group",
      "description": "Runs a numpy script in a python container.\nThe script finds the normal of the dot product of two random matrices.\nMatrix sizes are specified by the input parameter \"size\".\n",
      "arguments": {
        "required": [
          "numpy-test/memory",
          "numpy-test/size"
        ],
        "properties": {
          "numpy-test/memory": {
            "default": "20Gi",
            "type": "string",
            "pattern": "^[0-9]+[GMK]i$"
          },
          "numpy-test/size": {
            "default": 2000,
            "type": "integer"
          }
        }
      }
    }
  }
}
```