### PR TITLE
Use `workflows.argoproj.io` annotations for `title` and `description`

### DIFF
--- a/docs/explanations/description-annotation.md
+++ b/docs/explanations/description-annotation.md
@@ -1,3 +1,3 @@
 # Description Annotation
 
-On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) the `workflows.diamond.ac.uk/description` annotation (`metadata.annotations."workflows.diamond.ac.uk/parameter-ui-schema"`) is reserved for the specification of a plain text, human readable description.
+On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) the `workflows.argoproj.io/description` annotation is reserved for the specification of a plain text, human readable description.

--- a/docs/explanations/title-annotation.md
+++ b/docs/explanations/title-annotation.md
@@ -1,0 +1,3 @@
+# Title Annotation
+
+On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) the `workflows.argoproj.io/title` annotation is reserved for the specification of a plain text, human readable title.

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -3,7 +3,7 @@ kind: ClusterWorkflowTemplate
 metadata:
   name: numpy-benchmark
   annotations:
-    workflows.diamond.ac.uk/description: |
+    workflows.argoproj.io/description: |
       Runs a numpy script in a python container.
       The script finds the normal of the dot product of two random matrices.
       Matrix sizes are specified by the input parameter "size".

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -3,6 +3,7 @@ kind: ClusterWorkflowTemplate
 metadata:
   name: numpy-benchmark
   annotations:
+    workflows.argoproj.io/title: Numpy Benchmark
     workflows.argoproj.io/description: |
       Runs a numpy script in a python container.
       The script finds the normal of the dot product of two random matrices.

--- a/graph-proxy/src/graphql/workflow_templates.rs
+++ b/graph-proxy/src/graphql/workflow_templates.rs
@@ -24,6 +24,8 @@ struct WorkflowTemplate {
     name: String,
     /// The group who maintains the workflow template
     maintainer: String,
+    /// A human readable title for the workflow template
+    title: Option<String>,
     /// A human readable description of the workflow which is created
     description: Option<String>,
 }
@@ -43,6 +45,10 @@ impl TryFrom<argo_workflows_openapi::IoArgoprojWorkflowV1alpha1ClusterWorkflowTe
                 .labels
                 .remove("argocd.argoproj.io/instance")
                 .ok_or(WorkflowTemplateParsingError::MissingInstanceLabel)?,
+            title: value
+                .metadata
+                .annotations
+                .remove("workflows.argoproj.io/title"),
             description: value
                 .metadata
                 .annotations

--- a/graph-proxy/src/graphql/workflow_templates.rs
+++ b/graph-proxy/src/graphql/workflow_templates.rs
@@ -46,7 +46,7 @@ impl TryFrom<argo_workflows_openapi::IoArgoprojWorkflowV1alpha1ClusterWorkflowTe
             description: value
                 .metadata
                 .annotations
-                .remove("workflows.diamond.ac.uk/description"),
+                .remove("workflows.argoproj.io/description"),
         })
     }
 }


### PR DESCRIPTION
Found these [first party annotations](https://argo-workflows.readthedocs.io/en/latest/title-and-description/#title-and-description) - we should probably use them instead of inventing our own