### PR TITLE
Add UI Schema to `graph-proxy`

### DIFF
--- a/docs/explanations/ui-schema-annotation.md
+++ b/docs/explanations/ui-schema-annotation.md
@@ -1,0 +1,9 @@
+# UI Schema Annotation
+
+!!! note
+
+    See also [Parameter Schema Annotations](./parameter-schema-annotations.md)
+
+On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) the `workflows.diamond.ac.uk/ui-schema` annotation is reserved for the specification of [JSON Forms UI Schema](https://jsonforms.io/docs/uischema/). The schema must supply a `Control` for each of the parameters available in the template.
+
+The UI Schema is used to enhance layout in the `WorkflowTemplate`  and `ClusterWorkflowTemplate` submission forms. If no UI Schema is supplied the default [vertical layout](https://jsonforms.io/examples/layouts#vertical-layout) will be used.

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -19,6 +19,22 @@ metadata:
         "pattern": "^[0-9]+[GMK]i$",
         "default": "20Gi"
       }
+    workflows.diamond.ac.uk/ui-schema: |
+      {
+        "type": "VerticalLayout",
+        "elements": [
+          {
+            "type": "Control",
+            "scope": "#/properties/numpy-benchmark.memory",
+            "label": "Memory"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/numpy-benchmark.size",
+            "label": "Matrix Size"
+          }
+        ]
+      }
 spec:
   entrypoint: numpy-test
   templates:

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -9,9 +9,16 @@ metadata:
       The script finds the normal of the dot product of two random matrices.
       Matrix sizes are specified by the input parameter "size".
     workflows.diamond.ac.uk/parameter-schema.numpy-test.size: |
-      { "type": "integer", "default": 2000 }
+      {
+        "type": "integer",
+        "default": 2000
+      }
     workflows.diamond.ac.uk/parameter-schema.numpy-test.memory: |
-      { "type": "string", "pattern": "^[0-9]+[GMK]i$", "default": "20Gi" }
+      {
+        "type": "string",
+        "pattern": "^[0-9]+[GMK]i$",
+        "default": "20Gi"
+      }
 spec:
   entrypoint: numpy-test
   templates:


### PR DESCRIPTION
Adds the ability to define a [JSON Forms UI Schema](https://jsonforms.io/docs/uischema/) using the `workflows.diamond.ac.uk/ui-schema` annotation. This is exposed via the `graph-proxy` as the `uiSchema` field on a `WorkflowTemplate`, allowing Workflow Template creators to specify how a UI should be rendered for their template

**Example Query:**
```graphql
query {
  workflowTemplate(name: "numpy-benchmark") {
    name
    title
    description
    arguments
    uiSchema
  }
}
```

**Example Response:**
```json
{
  "data": {
    "workflowTemplate": {
      "name": "numpy-benchmark",
      "title": "Numpy Benchmark",
      "description": "Runs a numpy script in a python container.\nThe script finds the normal of the dot product of two random matrices.\nMatrix sizes are specified by the input parameter \"size\".\n",
      "arguments": {
        "required": [
          "numpy-test.memory",
          "numpy-test.size"
        ],
        "properties": {
          "numpy-test.memory": {
            "default": "20Gi",
            "type": "string"
          },
          "numpy-test.size": {
            "default": "2000",
            "type": "string"
          }
        }
      },
      "uiSchema": {
        "type": "VerticalLayout",
        "elements": [
          {
            "type": "Control",
            "scope": "#/properties/numpy-benchmark.memory",
            "label": "Memory"
          },
          {
            "type": "Control",
            "scope": "#/properties/numpy-benchmark.size",
            "label": "Matrix Size"
          }
        ]
      }
    }
  }
}
```