### PR TITLE
Fix parameter schema

### DIFF
--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -25,12 +25,12 @@ metadata:
         "elements": [
           {
             "type": "Control",
-            "scope": "#/properties/numpy-benchmark.memory",
+            "scope": "#/properties/numpy-test.memory",
             "label": "Memory"
           },
           {
             "type": "Control",
-            "scope": "#/properties/numpy-benchmark.size",
+            "scope": "#/properties/numpy-test.size",
             "label": "Matrix Size"
           }
         ]


### PR DESCRIPTION
A couple fixes to get parameter & UI schema working again:
- Query correct annotation for parameter schema (e.g. `workflows.diamond.ac.uk/parameter-schema.numpy-test.memory` instead of `numpy-test.memory`)
- Fix scope of `numpy-benchmark` example UI Schema Control scopes