### PR TITLE
Add workflow submission mutation to `graph-proxy`

### DIFF
--- a/docs/explanations/parameter-schema-annotations.md
+++ b/docs/explanations/parameter-schema-annotations.md
@@ -4,6 +4,6 @@
 
     See also [UI Schema Annotations](./ui-schema-annotation.md)
 
-On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) annotations prefixed with `workflows.diamond.ac.uk/paramter-schema` annotations with dot seperated subpaths of the step to which the parameter belongs and the parameter name (e.g. `metadata.annotations."workflows.diamond.ac.uk/parameter-schema.numpy-test.num-cores"`) are reserved for the specification of parameter [JSON Schema](https://json-schema.org/).
+On `WorkflowTemplate`s (`workflowtemplates.argoproj.io`) and `ClusterWorkflowTemplate`s (`clusterworkflowtemplates.argoproj.io`) annotations prefixed with `workflows.diamond.ac.uk/paramter-schema` annotations with a dot separated of the parameter name (e.g. `metadata.annotations."workflows.diamond.ac.uk/parameter-schema.num-cores"`) are reserved for the specification of a parameter [JSON Schema](https://json-schema.org/).
 
 The Schema is used to enhance type checking in the `WorkflowTemplate` and `ClusterWorkflowTemplate` submission forms. If no Schema is supplied one will be automatically generated in which parameters will be assumed to be of type `String` or `Enum` depending on whether they contain the `enum` declaration.

--- a/examples/numpy-benchmark.yaml
+++ b/examples/numpy-benchmark.yaml
@@ -8,12 +8,12 @@ metadata:
       Runs a numpy script in a python container.
       The script finds the normal of the dot product of two random matrices.
       Matrix sizes are specified by the input parameter "size".
-    workflows.diamond.ac.uk/parameter-schema.numpy-test.size: |
+    workflows.diamond.ac.uk/parameter-schema.size: |
       {
         "type": "integer",
         "default": 2000
       }
-    workflows.diamond.ac.uk/parameter-schema.numpy-test.memory: |
+    workflows.diamond.ac.uk/parameter-schema.memory: |
       {
         "type": "string",
         "pattern": "^[0-9]+[GMK]i$",
@@ -25,12 +25,12 @@ metadata:
         "elements": [
           {
             "type": "Control",
-            "scope": "#/properties/numpy-test.memory",
+            "scope": "#/properties/memory",
             "label": "Memory"
           },
           {
             "type": "Control",
-            "scope": "#/properties/numpy-test.size",
+            "scope": "#/properties/size",
             "label": "Matrix Size"
           }
         ]

--- a/graph-proxy/src/graphql/mod.rs
+++ b/graph-proxy/src/graphql/mod.rs
@@ -5,8 +5,7 @@ mod workflows;
 
 use self::{workflow_templates::WorkflowTemplatesQuery, workflows::WorkflowsQuery};
 use async_graphql::{
-    EmptyMutation, EmptySubscription, InputObject, MergedObject, Schema, SchemaBuilder,
-    SimpleObject,
+    EmptySubscription, InputObject, MergedObject, Schema, SchemaBuilder, SimpleObject,
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::extract::State;
@@ -16,18 +15,23 @@ use axum_extra::{
 };
 use lazy_static::lazy_static;
 use std::fmt::Display;
+use workflow_templates::WorkflowTemplatesMutation;
 
 /// The root schema of the service
-pub type RootSchema = Schema<Query, EmptyMutation, EmptySubscription>;
+pub type RootSchema = Schema<Query, Mutation, EmptySubscription>;
 
 /// A schema builder for the service
-pub fn root_schema_builder() -> SchemaBuilder<Query, EmptyMutation, EmptySubscription> {
-    Schema::build(Query::default(), EmptyMutation, EmptySubscription).enable_federation()
+pub fn root_schema_builder() -> SchemaBuilder<Query, Mutation, EmptySubscription> {
+    Schema::build(Query::default(), Mutation::default(), EmptySubscription).enable_federation()
 }
 
 /// The root query of the service
 #[derive(Debug, Clone, Default, MergedObject)]
 pub struct Query(WorkflowsQuery, WorkflowTemplatesQuery);
+
+/// The root mutation of the service
+#[derive(Debug, Clone, Default, MergedObject)]
+pub struct Mutation(WorkflowTemplatesMutation);
 
 /// Handles HTTP requests as GraphQL according to the provided [`Schema`]
 pub async fn graphql_handler(

--- a/graph-proxy/src/graphql/mod.rs
+++ b/graph-proxy/src/graphql/mod.rs
@@ -4,7 +4,10 @@ mod workflow_templates;
 mod workflows;
 
 use self::{workflow_templates::WorkflowTemplatesQuery, workflows::WorkflowsQuery};
-use async_graphql::{EmptyMutation, EmptySubscription, MergedObject, Schema, SchemaBuilder};
+use async_graphql::{
+    EmptyMutation, EmptySubscription, InputObject, MergedObject, Schema, SchemaBuilder,
+    SimpleObject,
+};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::extract::State;
 use axum_extra::{
@@ -12,6 +15,7 @@ use axum_extra::{
     TypedHeader,
 };
 use lazy_static::lazy_static;
+use std::fmt::Display;
 
 /// The root schema of the service
 pub type RootSchema = Schema<Query, EmptyMutation, EmptySubscription>;
@@ -40,4 +44,56 @@ pub async fn graphql_handler(
 
 lazy_static! {
     pub(self) static ref CLIENT: reqwest::Client = reqwest::Client::new();
+}
+
+/// A visit to an instrument as part of a session
+#[derive(Debug, Clone, SimpleObject)]
+struct Visit {
+    /// Project Proposal Code
+    proposal_code: String,
+    /// Project Proposal Number
+    proposal_number: u32,
+    /// Session visit Number
+    number: u32,
+}
+
+impl Display for Visit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{}-{}",
+            self.proposal_code, self.proposal_number, self.number
+        )
+    }
+}
+
+/// A visit to an instrument as part of a session
+#[derive(Debug, Clone, InputObject)]
+struct VisitInput {
+    /// Project Proposal Code
+    proposal_code: String,
+    /// Project Proposal Number
+    proposal_number: u32,
+    /// Session visit Number
+    number: u32,
+}
+
+impl From<VisitInput> for Visit {
+    fn from(visit: VisitInput) -> Self {
+        Self {
+            proposal_code: visit.proposal_code,
+            proposal_number: visit.proposal_number,
+            number: visit.number,
+        }
+    }
+}
+
+impl Display for VisitInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{}-{}",
+            self.proposal_code, self.proposal_number, self.number
+        )
+    }
 }

--- a/graph-proxy/src/graphql/workflows.rs
+++ b/graph-proxy/src/graphql/workflows.rs
@@ -16,7 +16,7 @@ use tracing::{debug, instrument};
 /// An error encountered when parsing the Argo Server API Workflow response
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::missing_docs_in_private_items)]
-enum WorkflowParsingError {
+pub(super) enum WorkflowParsingError {
     #[error("status.phase was not a recognised value")]
     UnrecognisedPhase,
     #[error("status.start_time was expected but was not present")]
@@ -31,7 +31,7 @@ enum WorkflowParsingError {
 
 /// A Workflow consisting of one or more [`Task`]s
 #[derive(Debug, SimpleObject)]
-struct Workflow {
+pub(super) struct Workflow {
     /// Metadata containing name, proposal code, proposal number and visit of a workflow
     #[graphql(flatten)]
     metadata: Arc<Metadata>,
@@ -49,7 +49,7 @@ struct Metadata {
 
 #[allow(clippy::missing_docs_in_private_items)]
 impl Workflow {
-    fn new(
+    pub(super) fn new(
         value: IoArgoprojWorkflowV1alpha1Workflow,
         visit: Visit,
     ) -> Result<Self, WorkflowParsingError> {


### PR DESCRIPTION
Adds a mutation to the `graph-proxy` service, allowing submission of a workflow using the a `ClusterWorkflowTemplate`.

A few changes were necessary for compatibility:
- `Workflow` `status` is made nullable to handle the case where a workflow has just been submitted and has not yet been given a status by the Argo Workflows Controller - a race condition not previously observed
- Namespacing was removed for template arguments (e.g. `numpy-test.size` -> `size`) to allow these values to be used in GraphQL inputs which accept `[a-zA-Z][_a-zA-Z0-9]*`

Also includes a few other small changes:
- Visit parameters are now captured and returned as a struct for the sake of code re-use
- `async-graphql`'s `Json` type is used in place of custom scalars for `parameters` and `uiSchema`

**Example Query:**

```graphql
mutation {
  submitWorkflowTemplate(
    name: "numpy-benchmark",
    visit: {
      proposalCode: "mg",
      proposalNumber: 36964,
      number: 1
    },
    parameters: {
    	memory: "10Gi",
      size: 1000
    }
  ) {
    name,
    visit {
      proposalCode,
      proposalNumber,
      number
    },
    status {
      __typename
    }
  }
}
```

**Example Response:**

```json
{
  "data": {
    "submitWorkflowTemplate": {
      "name": "numpy-benchmark-8fbfn",
      "visit": {
        "proposalCode": "mg",
        "proposalNumber": 36964,
        "number": 1
      },
      "status": null
    }
  }
}
```