### PR TITLE
Increase wait time for `argo-workflow` chainsaw test

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.10.0
+version: 0.10.1
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
               data:
                 members: '["member1", "member2"]'
         - sleep:
-            duration: 10s
+            duration: 15s
         - assert:
             resource:
               apiVersion: v1


### PR DESCRIPTION
This test is flakey, a longer sleep duration should hopefully reduce the number of false negatives we see