### PR TITLE
Increase argo workflow chainsaw test sleep duration to 20s

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.10.1
+version: 0.10.2
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
+++ b/charts/workflows/test-policy/argo-workflow/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
               data:
                 members: '["member1", "member2"]'
         - sleep:
-            duration: 15s
+            duration: 20s
         - assert:
             resource:
               apiVersion: v1


### PR DESCRIPTION
Still not a great fix, but hoping this might stop us seeing timeouts