### PR TITLE
Pin `kyverno` chart version to `3.2.6` in keyverno policy CI

### DIFF
--- a/.github/workflows/_kyverno_policy.yaml
+++ b/.github/workflows/_kyverno_policy.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Kyvenro
         run: |
-          helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace --set cleanupController.enabled=false --set reportsController.enabled=false
+          helm install kyverno kyverno/kyverno --version 3.2.6 --namespace kyverno --create-namespace --set cleanupController.enabled=false --set reportsController.enabled=false
           helm get manifest --namespace kyverno kyverno | yq e '. | select(.kind == "CustomResourceDefinition")' > /tmp/crds.yaml
 
       - name: Install Workflows CRDs


### PR DESCRIPTION
This was unpinned, thus it bumped to the new major version breaking various tests