### PR TITLE
Fix `$ref`s when merging parameter schema

### DIFF
--- a/graph-proxy/Cargo.lock
+++ b/graph-proxy/Cargo.lock
@@ -885,7 +885,6 @@ dependencies = [
  "opentelemetry_sdk",
  "regex",
  "reqwest",
- "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.3",
@@ -1494,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opentelemetry"

--- a/graph-proxy/Cargo.toml
+++ b/graph-proxy/Cargo.toml
@@ -21,7 +21,12 @@ axum = { version = "0.7.9" }
 axum-extra = { version = "0.9.6", features = ["typed-header"] }
 chrono = { workspace = true }
 clap = { version = "4.5.21", features = ["derive", "env"] }
-derive_more = { version = "1.0.0", features = ["deref", "from"] }
+derive_more = { version = "1.0.0", features = [
+  "deref",
+  "deref_mut",
+  "from",
+  "into",
+] }
 dotenvy = { version = "0.15.7" }
 lazy_static = { version = "1.5.0" }
 opentelemetry = { version = "0.22.0" }
@@ -30,10 +35,9 @@ opentelemetry-semantic-conventions = "0.14.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 regex = "1.11.1"
 reqwest = { version = "0.12.9", default-features = false, features = [
-    "rustls-tls",
-    "json",
+  "rustls-tls",
+  "json",
 ] }
-schemars = "0.8.21"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { version = "2.0.3" }

--- a/graph-proxy/src/graphql/mod.rs
+++ b/graph-proxy/src/graphql/mod.rs
@@ -1,3 +1,7 @@
+/// Workflow Template Paramer Schema
+mod parameter_schema;
+/// Workflow Template JSON Forms UI Schema
+mod ui_schema;
 /// GraphQL operations related to workflow templates
 mod workflow_templates;
 /// GraphQL operations related to workflows

--- a/graph-proxy/src/graphql/parameter_schema.rs
+++ b/graph-proxy/src/graphql/parameter_schema.rs
@@ -1,0 +1,169 @@
+use derive_more::derive::{Deref, DerefMut, From, Into};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use std::collections::{BTreeMap, HashMap};
+
+#[derive(Debug, thiserror::Error)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub(super) enum ParameterSchemaError {
+    #[error(r#"{0} was expected but was not present"#)]
+    MissingAnnotation(String),
+    #[error(r#"{annotation}" could not be parsed: {err}"#)]
+    Unparsable {
+        annotation: String,
+        err: serde_json::Error,
+    },
+}
+
+/// A JSON Schema, contents are expected to match Draft 2020-12
+#[derive(Debug, Clone, From, Into, Deref, DerefMut, Serialize, Deserialize)]
+pub(super) struct Schema(Value);
+
+/// A JSON Schema describing the arguments of a Workflow Template
+#[derive(Debug, Default)]
+pub(super) struct ArgumentSchema(BTreeMap<String, Schema>);
+
+impl Schema {
+    /// Updates references within the schema to use a specified path prefix
+    fn update_refs(&mut self, prefix: &str) {
+        #[allow(clippy::missing_docs_in_private_items)]
+        fn do_update(value: &mut Value, prefix: &str) {
+            match value {
+                Value::Object(ref mut schema) => {
+                    if let Some(Value::String(reference)) = schema.get_mut("$ref") {
+                        if let Some(reference_key) = reference.strip_prefix("#/") {
+                            *reference = format!("#/properties/{prefix}/{reference_key}")
+                        }
+                    }
+                    for value in schema.values_mut() {
+                        do_update(value, prefix);
+                    }
+                }
+                Value::Array(ref mut items) => items
+                    .iter_mut()
+                    .for_each(|schema| do_update(schema, prefix)),
+                _ => {}
+            }
+        }
+        do_update(&mut self.0, prefix);
+    }
+}
+
+impl From<ArgumentSchema> for Schema {
+    fn from(value: ArgumentSchema) -> Self {
+        Self(json! ({
+            "type": "object",
+            "required": value.0.keys().collect::<Vec<_>>(),
+            "properties": value.0.into_iter().map(|(name, mut schema)| {
+                schema.update_refs(&name);
+                (name, schema.0)
+            }).collect::<BTreeMap<_, _>>(),
+        }))
+    }
+}
+
+impl ArgumentSchema {
+    /// Adds a top level parameter to the schema
+    fn add_parameter(
+        &mut self,
+        parameter: &argo_workflows_openapi::IoArgoprojWorkflowV1alpha1Parameter,
+        annotations: &HashMap<String, String>,
+    ) -> Result<(), ParameterSchemaError> {
+        let schema = match Self::get_annotation_schema(parameter.name.clone(), annotations) {
+            Ok(schema) => Ok(schema),
+            Err(ParameterSchemaError::MissingAnnotation(_)) => match parameter.enum_.as_slice() {
+                [] => Ok(Self::infer_string_schema(
+                    parameter.description.as_deref(),
+                    parameter.value.as_deref(),
+                    parameter.default.as_deref(),
+                )),
+                options => Ok(Self::infer_enum_schema(
+                    parameter.description.as_deref(),
+                    options,
+                    parameter.value.as_deref(),
+                    parameter.default.as_deref(),
+                )),
+            },
+            Err(err) => Err(err),
+        }?;
+        self.0.insert(parameter.name.to_owned(), schema);
+        Ok(())
+    }
+
+    /// Retrieves an parses a schema from an annotation of the form "workflows.diamond.ac.uk/parameter-schema.{name}"
+    fn get_annotation_schema(
+        name: String,
+        annotations: &HashMap<String, String>,
+    ) -> Result<Schema, ParameterSchemaError> {
+        let annotation = format!("workflows.diamond.ac.uk/parameter-schema.{name}");
+        let schema = annotations
+            .get(&annotation)
+            .ok_or(ParameterSchemaError::MissingAnnotation(annotation.clone()))?;
+        serde_json::from_str(schema)
+            .map_err(|err| ParameterSchemaError::Unparsable { annotation, err })
+    }
+
+    /// Creates a Schema for a parameter of [`InstanceType::String`], with an optional default value
+    fn infer_string_schema(
+        description: Option<&str>,
+        value: Option<&str>,
+        default: Option<&str>,
+    ) -> Schema {
+        let mut contents = Map::new();
+        contents.insert("type".to_string(), "string".into());
+        if let Some(description) = description {
+            contents.insert("description".to_string(), description.into());
+        }
+        if let Some(default) = value.or(default) {
+            contents.insert("default".to_string(), default.into());
+        }
+        Schema(Value::Object(contents))
+    }
+
+    /// Creates a Schema for a parameter of [`InstanceType::String`], with a set of predefined options and an optional default value
+    fn infer_enum_schema(
+        description: Option<&str>,
+        options: &[String],
+        value: Option<&str>,
+        default: Option<&str>,
+    ) -> Schema {
+        let mut contents = Map::new();
+        contents.insert("type".to_string(), "string".into());
+        contents.insert("enum".to_string(), options.into());
+        if let Some(description) = description {
+            contents.insert("description".to_string(), description.into());
+        }
+        if let Some(default) = value.or(default) {
+            contents.insert("default".to_string(), default.into());
+        }
+        Schema(Value::Object(contents))
+    }
+
+    /// Create a [`ArgumentSchema`] from a Workflow Specification and associated annotations
+    pub(super) fn new(
+        spec: &argo_workflows_openapi::IoArgoprojWorkflowV1alpha1WorkflowSpec,
+        annotations: &HashMap<String, String>,
+    ) -> Result<Self, ParameterSchemaError> {
+        let mut arguments_schema = ArgumentSchema::default();
+        if let Some(arguments) = &spec.arguments {
+            for parameter in arguments.parameters.clone() {
+                arguments_schema.add_parameter(&parameter, annotations)?;
+            }
+        }
+        if let Some(entrypoint) = &spec.entrypoint {
+            if let Some(template) = spec.templates.iter().find(|template| {
+                template
+                    .name
+                    .as_ref()
+                    .is_some_and(|name| name == entrypoint)
+            }) {
+                if let Some(inputs) = &template.inputs {
+                    for parameter in &inputs.parameters {
+                        arguments_schema.add_parameter(parameter, annotations)?;
+                    }
+                }
+            }
+        }
+        Ok(arguments_schema)
+    }
+}

--- a/graph-proxy/src/graphql/ui_schema.rs
+++ b/graph-proxy/src/graphql/ui_schema.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Debug, thiserror::Error)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub(super) enum UiSchemaError {
+    #[error(r#"metadata.labels."workflows.diamond.ac.uk/ui-schema" could not be parsed: {0}"#)]
+    Unparsable(serde_json::Error),
+}
+
+/// A JSON Forms UI Schema
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[allow(clippy::missing_docs_in_private_items)]
+pub(super) enum UiSchema {
+    Control {
+        scope: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+    HorizontalLayout {
+        elements: Vec<UiSchema>,
+    },
+    VerticalLayout {
+        elements: Vec<UiSchema>,
+    },
+    Group {
+        label: String,
+        elements: Vec<UiSchema>,
+    },
+    Categorization {
+        elements: Vec<UiSchemaCategory>,
+    },
+}
+
+impl UiSchema {
+    /// Retrieves the UI Schema from the annotations on a [`WorkflowTemplate`], returns an error if parsing fails
+    pub(super) fn new(
+        annotations: &HashMap<String, String>,
+    ) -> Result<Option<Self>, UiSchemaError> {
+        annotations
+            .get("workflows.diamond.ac.uk/ui-schema")
+            .map(|annotation| serde_json::from_str(annotation))
+            .transpose()
+            .map_err(UiSchemaError::Unparsable)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub(super) struct UiSchemaCategory {
+    #[serde(serialize_with = "UiSchemaCategory::r#type")]
+    r#type: (),
+    label: String,
+    elements: Vec<UiSchema>,
+}
+
+impl UiSchemaCategory {
+    #[allow(clippy::missing_docs_in_private_items)]
+    fn r#type<S: Serializer>(_: &(), s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str("category")
+    }
+}

--- a/graph-proxy/src/graphql/workflow_templates.rs
+++ b/graph-proxy/src/graphql/workflow_templates.rs
@@ -1,4 +1,9 @@
-use super::{workflows::Workflow, VisitInput, CLIENT};
+use super::{
+    parameter_schema::{ArgumentSchema, ParameterSchemaError, Schema},
+    ui_schema::{UiSchema, UiSchemaError},
+    workflows::Workflow,
+    VisitInput, CLIENT,
+};
 use crate::ArgoServerUrl;
 use anyhow::anyhow;
 use argo_workflows_openapi::APIResult;
@@ -7,8 +12,6 @@ use async_graphql::{
     Context, Json, Object,
 };
 use axum_extra::headers::{authorization::Bearer, Authorization};
-use schemars::schema::{InstanceType, Metadata, SchemaObject, SingleOrVec, StringValidation};
-use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
 use std::{collections::HashMap, ops::Deref};
 use tracing::{debug, instrument};
@@ -18,15 +21,10 @@ use tracing::{debug, instrument};
 enum WorkflowTemplateParsingError {
     #[error(r#"metadata.labels."argocd.argoproj.io/instance" was expected but was not present"#)]
     MissingInstanceLabel,
-    #[error(r#"{0} was expected but was not present"#)]
-    MissingParameterSchemaAnnotation(String),
-    #[error(r#"{annotation}" could not be parsed: {err}"#)]
-    UnparsableParameterSchema {
-        annotation: String,
-        err: serde_json::Error,
-    },
-    #[error(r#"metadata.labels."workflows.diamond.ac.uk/ui-schema" could not be parsed: {0}"#)]
-    UnparsableUiSchema(serde_json::Error),
+    #[error("Could not parse parameter schema")]
+    ParameterSchemaError(#[from] ParameterSchemaError),
+    #[error("Could not parse UI schema")]
+    UiSchemaError(#[from] UiSchemaError),
 }
 
 /// A Template which specifies how to produce a [`Workflow`]
@@ -61,182 +59,15 @@ impl WorkflowTemplate {
     }
 
     /// A JSON Schema describing the arguments of a Workflow Template
-    async fn arguments(&self) -> Result<Json<ArgumentSchema>, WorkflowTemplateParsingError> {
-        Ok(Json(ArgumentSchema::new(
-            &self.spec,
-            &self.metadata.annotations,
-        )?))
+    async fn arguments(&self) -> Result<Json<Value>, WorkflowTemplateParsingError> {
+        Ok(Json(
+            Schema::from(ArgumentSchema::new(&self.spec, &self.metadata.annotations)?).into(),
+        ))
     }
 
     /// A JSON Forms UI Schema describing how to render the arguments of the Workflow Template
     async fn ui_schema(&self) -> Result<Option<Json<UiSchema>>, WorkflowTemplateParsingError> {
         Ok(UiSchema::new(&self.metadata.annotations)?.map(Json))
-    }
-}
-
-/// A JSON Schema describing the arguments of a Workflow Template
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct ArgumentSchema(SchemaObject);
-
-impl ArgumentSchema {
-    /// Adds a top level parameter to the schema
-    fn add_parameter(
-        &mut self,
-        parameter: &argo_workflows_openapi::IoArgoprojWorkflowV1alpha1Parameter,
-        annotations: &HashMap<String, String>,
-    ) -> Result<(), WorkflowTemplateParsingError> {
-        let schema = match Self::get_annotation_schema(parameter.name.clone(), annotations) {
-            Ok(schema) => Ok(schema),
-            Err(WorkflowTemplateParsingError::MissingParameterSchemaAnnotation(_)) => {
-                match parameter.enum_.as_slice() {
-                    [] => Ok(Self::infer_string_schema(
-                        parameter.description.as_ref(),
-                        parameter.value.as_ref(),
-                    )),
-                    options => Ok(Self::infer_enum_schema(
-                        parameter.description.as_ref(),
-                        options,
-                        parameter.value.as_ref(),
-                    )),
-                }
-            }
-            Err(err) => Err(err),
-        }?;
-        let validator = self.0.object();
-        validator
-            .properties
-            .insert(parameter.name.clone(), schema.into());
-        validator.required.insert(parameter.name.clone());
-        Ok(())
-    }
-
-    /// Retrieves an parses a schema from an annotation of the form "workflows.diamond.ac.uk/parameter-schema.{name}"
-    fn get_annotation_schema(
-        name: String,
-        annotations: &HashMap<String, String>,
-    ) -> Result<SchemaObject, WorkflowTemplateParsingError> {
-        let annotation = format!("workflows.diamond.ac.uk/parameter-schema.{name}");
-        let schema = annotations.get(&annotation).ok_or(
-            WorkflowTemplateParsingError::MissingParameterSchemaAnnotation(annotation.clone()),
-        )?;
-        serde_json::from_str::<SchemaObject>(schema).map_err(|err| {
-            WorkflowTemplateParsingError::UnparsableParameterSchema { annotation, err }
-        })
-    }
-
-    /// Creates a Schema for a parameter of [`InstanceType::String`], with an optional default value
-    fn infer_string_schema(description: Option<&String>, default: Option<&String>) -> SchemaObject {
-        SchemaObject {
-            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
-            metadata: Some(Box::new(Metadata {
-                description: description.cloned(),
-                default: default.cloned().map(Value::String),
-                ..Default::default()
-            })),
-            string: Some(Box::new(StringValidation::default())),
-            ..Default::default()
-        }
-    }
-
-    /// Creates a Schema for a parameter of [`InstanceType::String`], with a set of predefined options and an optional default value
-    fn infer_enum_schema(
-        description: Option<&String>,
-        options: &[String],
-        default: Option<&String>,
-    ) -> SchemaObject {
-        SchemaObject {
-            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
-            metadata: Some(Box::new(Metadata {
-                description: description.cloned(),
-                default: default.cloned().map(Value::String),
-                ..Default::default()
-            })),
-            enum_values: Some(options.iter().cloned().map(Value::String).collect()),
-            ..Default::default()
-        }
-    }
-
-    /// Create a [`ArgumentSchema`] from a Workflow Specification and associated annotations
-    fn new(
-        spec: &argo_workflows_openapi::IoArgoprojWorkflowV1alpha1WorkflowSpec,
-        annotations: &HashMap<String, String>,
-    ) -> Result<Self, WorkflowTemplateParsingError> {
-        let mut arguments_schema = ArgumentSchema::default();
-        arguments_schema.0.instance_type =
-            Some(SingleOrVec::Single(Box::new(InstanceType::Object)));
-        if let Some(arguments) = &spec.arguments {
-            for parameter in arguments.parameters.clone() {
-                arguments_schema.add_parameter(&parameter, annotations)?;
-            }
-        }
-        if let Some(entrypoint) = &spec.entrypoint {
-            if let Some(template) = spec.templates.iter().find(|template| {
-                template
-                    .name
-                    .as_ref()
-                    .is_some_and(|name| name == entrypoint)
-            }) {
-                if let Some(inputs) = &template.inputs {
-                    for parameter in &inputs.parameters {
-                        arguments_schema.add_parameter(parameter, annotations)?;
-                    }
-                }
-            }
-        }
-        Ok(arguments_schema)
-    }
-}
-
-/// A JSON Forms UI Schema
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "type")]
-#[allow(clippy::missing_docs_in_private_items)]
-enum UiSchema {
-    Control {
-        scope: String,
-        label: Option<String>,
-    },
-    HorizontalLayout {
-        elements: Vec<UiSchema>,
-    },
-    VerticalLayout {
-        elements: Vec<UiSchema>,
-    },
-    Group {
-        label: String,
-        elements: Vec<UiSchema>,
-    },
-    Categorization {
-        elements: Vec<UiSchemaCategory>,
-    },
-}
-
-impl UiSchema {
-    /// Retrieves the UI Schema from the annotations on a [`WorkflowTemplate`], returns an error if parsing fails
-    fn new(
-        annotations: &HashMap<String, String>,
-    ) -> Result<Option<Self>, WorkflowTemplateParsingError> {
-        annotations
-            .get("workflows.diamond.ac.uk/ui-schema")
-            .map(|annotation| serde_json::from_str(annotation))
-            .transpose()
-            .map_err(WorkflowTemplateParsingError::UnparsableUiSchema)
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(clippy::missing_docs_in_private_items)]
-struct UiSchemaCategory {
-    #[serde(serialize_with = "UiSchemaCategory::r#type")]
-    r#type: (),
-    label: String,
-    elements: Vec<UiSchema>,
-}
-
-impl UiSchemaCategory {
-    #[allow(clippy::missing_docs_in_private_items)]
-    fn r#type<S: Serializer>(_: &(), s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str("category")
     }
 }
 


### PR DESCRIPTION
Parameter schema are now treated as root schema, and their references (`$refs`) are now mutated to point to their own `$defs`.