### PR TITLE
Add cards to dashboard

### DIFF
--- a/frontend/dashboard/src/App.tsx
+++ b/frontend/dashboard/src/App.tsx
@@ -1,9 +1,0 @@
-function App() {
-  return (
-    <>
-    <h1>Hello Workflow Dashboard!</h1>
-    </>
-  )
-}
-
-export default App

--- a/frontend/dashboard/src/components/dashboard.tsx
+++ b/frontend/dashboard/src/components/dashboard.tsx
@@ -1,0 +1,97 @@
+import { Container, 
+         Grid2 as Grid,
+         Card,
+         CardContent,
+         Typography,
+         CardActionArea
+} from '@mui/material';
+import React from 'react';
+
+const workflowsCard = (
+  <React.Fragment>
+    <CardActionArea href="/workflows">
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="div">
+          Workflows
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          Provides an overview of current and past workflows for 
+          a given visit.
+        </Typography>
+      </CardContent>
+    </CardActionArea>
+  </React.Fragment>
+)
+
+const templatesCard = (
+  <React.Fragment>
+    <CardActionArea href='/templates'>
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="div">
+          Templates
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          Provides an overview of all available workflowTemplates and Sensors.
+        </Typography>
+      </CardContent>
+    </CardActionArea>
+  </React.Fragment>
+)
+
+const documentationCard = (
+  <React.Fragment>
+    <CardActionArea href='https://diamondlightsource.github.io/workflows/docs' target='_blank'>
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="div">
+          Documentation
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          Full user documentation with tutorials, how-tos, explanations and references.
+        </Typography>
+      </CardContent>
+    </CardActionArea>
+  </React.Fragment>
+)
+
+const argoCard = (
+  <React.Fragment>
+    <CardActionArea href='https:///workflows.diamond.ac.uk' target='_blank'>
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="div">
+          Argo Web UI
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          The native Argo Workflows dashboard. 
+        </Typography>
+      </CardContent>
+    </CardActionArea>
+  </React.Fragment>
+)
+
+function Dashboard() {
+  return (
+    <>
+    <Container maxWidth="sm">
+      <Typography variant='h3' align='center' gutterBottom>
+        Workflows at Diamond
+      </Typography>
+      <Grid container spacing={{ xs: 2, sm: 2, md: 3}} columns={{ xs: 2, sm: 4, md: 6 }}>
+          <Grid key={"workflows"} size={{ xs:2, sm: 2, md: 3 }}>
+            <Card>{workflowsCard}</Card>
+          </Grid>
+          <Grid key={"templates"} size={{ xs: 2, sm: 2, md: 3 }}>
+            <Card>{templatesCard}</Card>
+          </Grid>
+          <Grid key={"documentation"} size={{ xs: 2, sm: 2, md: 3 }}>
+            <Card>{documentationCard}</Card>
+          </Grid>
+          <Grid key={"argo"} size={{ xs: 2, sm: 2, md: 3 }}>
+            <Card>{argoCard}</Card>
+          </Grid>
+      </Grid>
+    </Container>
+    </>
+  )
+}
+
+export default Dashboard

--- a/frontend/dashboard/src/components/dashboard.tsx
+++ b/frontend/dashboard/src/components/dashboard.tsx
@@ -75,18 +75,18 @@ function Dashboard() {
       <Typography variant='h3' align='center' gutterBottom>
         Workflows at Diamond
       </Typography>
-      <Grid container spacing={{ xs: 2, sm: 2, md: 3}} columns={{ xs: 2, sm: 4, md: 6 }}>
+      <Grid container alignItems="stretch" spacing={{ xs: 2, sm: 2, md: 3}} columns={{ xs: 2, sm: 4, md: 6 }}>
           <Grid key={"workflows"} size={{ xs:2, sm: 2, md: 3 }}>
-            <Card>{workflowsCard}</Card>
+            <Card style={{height: "100%"}}>{workflowsCard}</Card>
           </Grid>
           <Grid key={"templates"} size={{ xs: 2, sm: 2, md: 3 }}>
-            <Card>{templatesCard}</Card>
+            <Card style={{height: "100%"}}>{templatesCard}</Card>
           </Grid>
           <Grid key={"documentation"} size={{ xs: 2, sm: 2, md: 3 }}>
-            <Card>{documentationCard}</Card>
+            <Card style={{height: "100%"}}>{documentationCard}</Card>
           </Grid>
-          <Grid key={"argo"} size={{ xs: 2, sm: 2, md: 3 }}>
-            <Card>{argoCard}</Card>
+          <Grid key={"argo"} size={{ xs: 2, sm: 2, md: 3 }} >
+            <Card style={{height: "100%"}}>{argoCard}</Card>
           </Grid>
       </Grid>
     </Container>

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -6,19 +6,24 @@ import {
   createBrowserRouter,
   RouterProvider
 } from "react-router-dom";
-import App from "./App.tsx";
+import Dashboard from "./components/dashboard.tsx";
 import WorkflowsList from "./routes/workflows.tsx";
+import TemplatesList from "./routes/templates.tsx";
 import ErrorPage from "./errorpage.tsx";
 
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <App />,
+    element: <Dashboard />,
     errorElement: <ErrorPage />
   },
   {
     path: "workflows",
     element: <WorkflowsList />
+  },
+  {
+    path: "templates",
+    element: <TemplatesList />
   }
 ]);
 

--- a/frontend/dashboard/src/routes/templates.tsx
+++ b/frontend/dashboard/src/routes/templates.tsx
@@ -1,16 +1,16 @@
 import { Container, Typography } from "@mui/material";
 
-function WorkflowsList() {
+function TemplatesList() {
 
   return (
     <>
       <Container maxWidth="sm">
         <Typography variant='h3' align='center' gutterBottom>
-          List of Workflows
+          List of Templates
         </Typography> 
       </Container> 
     </>
   )
 }
 
-export default WorkflowsList
+export default TemplatesList

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "@jsonforms/material-renderers": "^3.4.0",
     "@jsonforms/react": "^3.4.0",
     "@mui/icons-material": "^5.16.7",
-    "@mui/material": "^5.16.7",
+    "@mui/material": "^6.1.7",
     "@mui/x-date-pickers": "^7.22.2",
     "@xyflow/react": "^12.3.4",
     "ajv": "^8.17.1",

--- a/frontend/workflows-lib/lib/components/workflow/TasksTable.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/TasksTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Grid, Paper, Typography, useTheme } from "@mui/material";
+import { Grid2 as Grid, Paper, Typography, useTheme } from "@mui/material";
 import { Task } from "../../types";
 import { getTaskStatusIcon } from "../common/StatusIcons";
 
@@ -12,7 +12,7 @@ const TasksTable: React.FC<TaskTableProps> = ({ tasks }) => {
   return (
     <Grid container spacing={1.5} padding={2} sx={{ overflow: "auto" }}>
       {tasks.map((task) => (
-        <Grid item key={task.id} xs="auto">
+        <Grid key={task.id} size={{xs:"auto"}}>
           <Paper
             elevation={8}
             sx={{

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -227,7 +227,7 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
-"@emotion/cache@^11.11.0", "@emotion/cache@^11.13.0":
+"@emotion/cache@^11.13.0", "@emotion/cache@^11.13.1":
   version "11.13.1"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.13.1.tgz#fecfc54d51810beebf05bf2a161271a1a91895d7"
   integrity sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==
@@ -269,7 +269,7 @@
     "@emotion/weak-memoize" "^0.4.0"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^1.2.0", "@emotion/serialize@^1.3.0", "@emotion/serialize@^1.3.1":
+"@emotion/serialize@^1.2.0", "@emotion/serialize@^1.3.0", "@emotion/serialize@^1.3.1", "@emotion/serialize@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.2.tgz#e1c1a2e90708d5d85d81ccaee2dfeb3cc0cccf7a"
   integrity sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==
@@ -713,10 +713,10 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@mui/core-downloads-tracker@^5.16.7":
-  version "5.16.7"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.7.tgz#182a325a520f7ebd75de051fceabfc0314cfd004"
-  integrity sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==
+"@mui/core-downloads-tracker@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.1.7.tgz#80f4327804ee97b6af7b11980f87e29dc2231226"
+  integrity sha512-POuIBi80BZBogQkG4PQKIGwy4QFwB+kOr+OI4k7Znh7LqMAIhwB9OC00l6M+w1GrZJYj3T8R5WX8G6QAIvoVEw==
 
 "@mui/icons-material@^5.16.7":
   version "5.16.7"
@@ -725,75 +725,65 @@
   dependencies:
     "@babel/runtime" "^7.23.9"
 
-"@mui/material@^5.16.7":
-  version "5.16.7"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.16.7.tgz#6e814e2eefdaf065a769cecf549c3569e107a50b"
-  integrity sha512-cwwVQxBhK60OIOqZOVLFt55t01zmarKJiJUWbk0+8s/Ix5IaUzAShqlJchxsIQ4mSrWqgcKCCXKtIlG5H+/Jmg==
+"@mui/material@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-6.1.7.tgz#a30dcfdae6e3cbb184669813d6b3a8addd4540ee"
+  integrity sha512-KsjujQL/A2hLd1PV3QboF+W6SSL5QqH6ZlSuQoeYz9r69+TnyBFIevbYLxdjJcJmGBjigL5pfpn7hTGop+vhSg==
   dependencies:
-    "@babel/runtime" "^7.23.9"
-    "@mui/core-downloads-tracker" "^5.16.7"
-    "@mui/system" "^5.16.7"
-    "@mui/types" "^7.2.15"
-    "@mui/utils" "^5.16.6"
+    "@babel/runtime" "^7.26.0"
+    "@mui/core-downloads-tracker" "^6.1.7"
+    "@mui/system" "^6.1.7"
+    "@mui/types" "^7.2.19"
+    "@mui/utils" "^6.1.7"
     "@popperjs/core" "^2.11.8"
-    "@types/react-transition-group" "^4.4.10"
-    clsx "^2.1.0"
+    "@types/react-transition-group" "^4.4.11"
+    clsx "^2.1.1"
     csstype "^3.1.3"
     prop-types "^15.8.1"
     react-is "^18.3.1"
     react-transition-group "^4.4.5"
 
-"@mui/private-theming@^5.16.6":
-  version "5.16.6"
-  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.16.6.tgz#547671e7ae3f86b68d1289a0b90af04dfcc1c8c9"
-  integrity sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==
+"@mui/private-theming@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-6.1.7.tgz#9415c32eb567194b713941243cf18fde09981ba1"
+  integrity sha512-uLbfUSsug5K0LVkv0PI6Flste3le8+6WSL2omdTiYde93P89Qr7pKr8TA6d2yXfr+Bm+SvD8/fGnkaRwFkryuQ==
   dependencies:
-    "@babel/runtime" "^7.23.9"
-    "@mui/utils" "^5.16.6"
+    "@babel/runtime" "^7.26.0"
+    "@mui/utils" "^6.1.7"
     prop-types "^15.8.1"
 
-"@mui/styled-engine@^5.16.6":
-  version "5.16.6"
-  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.16.6.tgz#60110c106dd482dfdb7e2aa94fd6490a0a3f8852"
-  integrity sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==
+"@mui/styled-engine@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-6.1.7.tgz#2e38642325afe473dd14349c95a56e947640b154"
+  integrity sha512-Ou4CxN7MQmwrfG1Pu6EYjPgPChQXxPDJrwgizLXlRPOad5qAq4gYXRuzrGQ2DfGjjwmJhjI8T6A0SeapAZPGig==
   dependencies:
-    "@babel/runtime" "^7.23.9"
-    "@emotion/cache" "^11.11.0"
+    "@babel/runtime" "^7.26.0"
+    "@emotion/cache" "^11.13.1"
+    "@emotion/serialize" "^1.3.2"
+    "@emotion/sheet" "^1.4.0"
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
-"@mui/system@^5.16.7":
-  version "5.16.7"
-  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.16.7.tgz#4583ca5bf3b38942e02c15a1e622ba869ac51393"
-  integrity sha512-Jncvs/r/d/itkxh7O7opOunTqbbSSzMTHzZkNLM+FjAOg+cYAZHrPDlYe1ZGKUYORwwb2XexlWnpZp0kZ4AHuA==
+"@mui/system@^6.1.7":
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-6.1.7.tgz#041d450b842d5c2fb1608d4027360ad2ba25bd9a"
+  integrity sha512-qbMGgcC/FodpuRSfjXlEDdbNQaW++eATh0vNBcPUv2/YXSpReoOpoT9FhogxEBNks+aQViDXBRZKh6HX2fVmwg==
   dependencies:
-    "@babel/runtime" "^7.23.9"
-    "@mui/private-theming" "^5.16.6"
-    "@mui/styled-engine" "^5.16.6"
-    "@mui/types" "^7.2.15"
-    "@mui/utils" "^5.16.6"
-    clsx "^2.1.0"
+    "@babel/runtime" "^7.26.0"
+    "@mui/private-theming" "^6.1.7"
+    "@mui/styled-engine" "^6.1.7"
+    "@mui/types" "^7.2.19"
+    "@mui/utils" "^6.1.7"
+    clsx "^2.1.1"
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
-"@mui/types@^7.2.15", "@mui/types@^7.2.19":
+"@mui/types@^7.2.19":
   version "7.2.19"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.19.tgz#c941954dd24393fdce5f07830d44440cf4ab6c80"
   integrity sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==
 
-"@mui/utils@^5.16.6":
-  version "5.16.6"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.16.6.tgz#905875bbc58d3dcc24531c3314a6807aba22a711"
-  integrity sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==
-  dependencies:
-    "@babel/runtime" "^7.23.9"
-    "@mui/types" "^7.2.15"
-    "@types/prop-types" "^15.7.12"
-    clsx "^2.1.1"
-    prop-types "^15.8.1"
-    react-is "^18.3.1"
-
-"@mui/utils@^5.16.6 || ^6.0.0":
+"@mui/utils@^5.16.6 || ^6.0.0", "@mui/utils@^6.1.7":
   version "6.1.7"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.1.7.tgz#0959d9772ae13c6ceac984a493e06aebb9087e71"
   integrity sha512-Gr7cRZxBoZ0BIa3Xqf/2YaUrBLyNPJvXPQH3OsD9WMZukI/TutibbQBVqLYpgqJn8pKSjbD50Yq2auG0wI1xOw==
@@ -1363,7 +1353,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.12", "@types/prop-types@^15.7.13":
+"@types/prop-types@*", "@types/prop-types@^15.7.13":
   version "15.7.13"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
   integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
@@ -1390,7 +1380,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.4.10", "@types/react-transition-group@^4.4.11":
+"@types/react-transition-group@^4.4.11":
   version "4.4.11"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.11.tgz#d963253a611d757de01ebb241143b1017d5d63d5"
   integrity sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==
@@ -1996,7 +1986,7 @@ clsx@^1.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
-clsx@^2.1.0, clsx@^2.1.1:
+clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==


### PR DESCRIPTION
needs #270 

- Upgrades MUI to v6
- Replaces Grid with Grid2
- Creates a minimal dashboard with 4 cards

![image](https://github.com/user-attachments/assets/4327f642-ac96-43f2-89e2-65434be7f5e2)

with the first two cards directing to /workflows and /templates respectively while the last two cards point to external pages.