### PR TITLE
Fix `sessionspaces` ispyb secret reference

### DIFF
--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.1.0-rc22
 dependencies:
   - name: common

--- a/charts/sessionspaces/templates/deployment.yaml
+++ b/charts/sessionspaces/templates/deployment.yaml
@@ -37,8 +37,8 @@ spec:
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.database.password.secretName }}
-                  key: {{ $.Values.database.password.secretKey }}
+                  name: {{ default (printf "%s-ispyb" (include "common.names.fullname" $)) $.Values.database.password.secretName }}
+                  key: {{ default "password" $.Values.database.password.secretKey }}
             - name: DATABASE_URL
               value: {{ include "sessionspaces.databaseURL" $ }}
             - name: LDAP_URL

--- a/charts/sessionspaces/values.yaml
+++ b/charts/sessionspaces/values.yaml
@@ -2,8 +2,8 @@ database:
   host: mysql://ispybdbproxy.diamond.ac.uk:4306/ispyb
   user: ispyb_ro
   password:
-    secretName: ispyb
-    secretKey: password
+    secretName: ""
+    secretKey: ""
 ldapUrl: ldap://ldapmaster.diamond.ac.uk
 requestRate: 1
 


### PR DESCRIPTION
The `sessionspaces` deployment is currently trying to reference `secrets/ispyb` instead of `secrets/sessionspaces-ispyb`