### PR TITLE
Bump charts to latest app version

### DIFF
--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -3,8 +3,8 @@ name: dashboard
 description: A dashboard for Diamond workflows
 type: application
 
-version: 0.1.0
-appVersion: 0.1.0-rc23
+version: 0.1.1
+appVersion: 0.1.0-rc24
 
 dependencies:
   - name: common

--- a/charts/graph-proxy/Chart.yaml
+++ b/charts/graph-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: graph-proxy
 description: A GraphQL proxy for the Argo Workflows Server
 type: application
-version: 0.2.1
-appVersion: 0.1.0-rc22
+version: 0.2.2
+appVersion: 0.1.0-rc24
 dependencies:
   - name: common
     version: 2.23.0

--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
-version: 0.3.2
-appVersion: 0.1.0-rc22
+version: 0.3.3
+appVersion: 0.1.0-rc24
 dependencies:
   - name: common
     version: 2.23.0


### PR DESCRIPTION
Updated sessionspaces, graph-proxy and dashboard charts to use  `0.1.0-rc24`