### PR TITLE
Bump `argo-workflows` chart version to `0.45.0`

### DIFF
--- a/charts/workflows/Chart.lock
+++ b/charts/workflows/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: argo-workflows
   repository: https://argoproj.github.io/argo-helm
-  version: 0.42.3
+  version: 0.45.0
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 14.3.9
 - name: oauth2-proxy
   repository: https://oauth2-proxy.github.io/manifests
   version: 7.7.9
-digest: sha256:bfbbf2e60f98bd96560ebbc61f540fca4be837fbab33b0a85d8a7fce7c9d96c9
-generated: "2024-11-20T11:44:13.132203843Z"
+digest: sha256:486bb7358896d4feb13c63b77fcc21c7e96cac890dae7d052ce9549bcce0dbdb
+generated: "2024-11-27T13:50:33.586051741Z"

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,12 +3,12 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.12.0
+version: 0.12.1
 
 dependencies:
   - name: argo-workflows
     repository: https://argoproj.github.io/argo-helm
-    version: 0.42.3
+    version: 0.45.0
     condition: argo-workflows.enabled
   - name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Luckily there are no [breaking changes](https://argo-workflows.readthedocs.io/en/latest/upgrading/#upgrading-to-v36) which will impact us between `argo-workflows` `v0.5.11` (helm `0.42.3`) and `v0.6.0` (`0.45.0`)