### PR TITLE
Fix `graph-proxy` docker image caching

### DIFF
--- a/graph-proxy/Dockerfile
+++ b/graph-proxy/Dockerfile
@@ -13,6 +13,7 @@ COPY Cargo.toml Cargo.lock ./
 
 RUN mkdir src \
   && echo "fn main() {}" > src/main.rs \
+  && touch --date @0 src/main.rs \
   && cargo build --release
 
 COPY . .

--- a/graph-proxy/Dockerfile
+++ b/graph-proxy/Dockerfile
@@ -6,17 +6,19 @@ WORKDIR /app
 
 RUN rustup component add rustfmt
 
-COPY argo-workflows-openapi argo-workflows-openapi
+COPY argo-workflows-openapi/Cargo.toml argo-workflows-openapi/Cargo.toml
+COPY argo-workflows-openapi/build.rs argo-workflows-openapi/build.rs
+COPY argo-workflows-openapi/src/lib.rs argo-workflows-openapi/src/lib.rs
 COPY Cargo.toml Cargo.lock ./
 
 RUN mkdir src \
-    && echo "fn main() {}" > src/main.rs \
-    && cargo build --release
+  && echo "fn main() {}" > src/main.rs \
+  && cargo build --release
 
 COPY . .
 
 RUN touch src/main.rs \
-    && cargo build --release
+  && cargo build --release
 
 FROM gcr.io/distroless/cc-debian12@sha256:3b75fdd33932d16e53a461277becf57c4f815c6cee5f6bc8f52457c095e004c8 AS deploy
 


### PR DESCRIPTION
By only copying the necessary build files (`Cargo.toml`, `build.rs` & `lib.rs`) we can ensure cache hits for the graph-proxy build, thus significantly speeding up build times for the container in CI
By ensuring the temporary `main.rs` has a consistent time stamp the layer cache for the initial `cargo build --release` is not invalidated

Previously: `5m17s`
Now: `29s`