### PR TITLE
Fix `sessionspaces` docker image caching

### DIFF
--- a/.github/workflows/_sessionspaces_code.yaml
+++ b/.github/workflows/_sessionspaces_code.yaml
@@ -13,8 +13,10 @@ jobs:
           - 3306:3306
         env:
           MARIADB_ROOT_PASSWORD: rootpassword
-        options: >
+        options: >-
           --health-cmd "/usr/local/bin/healthcheck.sh --defaults-file=/ispyb/.my.cnf --connect"
+          --health-interval 1s
+          --health-retries 60
     env:
       DATABASE_URL: mysql://root:rootpassword@localhost/ispyb_build
     steps:
@@ -56,8 +58,10 @@ jobs:
           - 3306:3306
         env:
           MARIADB_ROOT_PASSWORD: rootpassword
-        options: >
+        options: >-
           --health-cmd "/usr/local/bin/healthcheck.sh --defaults-file=/ispyb/.my.cnf --connect"
+          --health-interval 1s
+          --health-retries 60
     env:
       DATABASE_URL: mysql://root:rootpassword@localhost/ispyb_build
     steps:

--- a/.github/workflows/_sessionspaces_container.yaml
+++ b/.github/workflows/_sessionspaces_container.yaml
@@ -13,8 +13,10 @@ jobs:
           - 3306:3306
         env:
           MARIADB_ROOT_PASSWORD: rootpassword
-        options: >
+        options: >-
           --health-cmd "/usr/local/bin/healthcheck.sh --defaults-file=/ispyb/.my.cnf --connect"
+          --health-interval 1s
+          --health-retries 60
     permissions:
       contents: read
       packages: write

--- a/sessionspaces/Dockerfile
+++ b/sessionspaces/Dockerfile
@@ -7,12 +7,13 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 
 RUN mkdir src && echo "fn main() {}" > src/main.rs \
-    && cargo build --release
+  && touch --date @0 src/main.rs \
+  && cargo build --release
 
 COPY . .
 
 RUN touch src/main.rs \
-    && cargo build --release
+  && cargo build --release
 
 FROM gcr.io/distroless/cc-debian12@sha256:2fb69596e692931f909c4c69ab09e50608959eaf8898c44fa64db741a23588b0 AS deploy
 


### PR DESCRIPTION
By ensuring the temporary `main.rs` has a consistent time stamp the layer cache for the initial `cargo build --release` is not invalidated
And running the startup healthcheck on service containers more frequently (`1s` interval instead of exponential backoff)

Lint:
- Previous: `1m55s`
- Now: `1m15s`

Test:
- Previous: `1m12s`
- Now: `45s`

Container:
- Previous: `1m27s`
- Now: `48s`