### PR TITLE
Use correct upstream url for `graph-proxy`

### DIFF
--- a/charts/graph-proxy/Chart.yaml
+++ b/charts/graph-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graph-proxy
 description: A GraphQL proxy for the Argo Workflows Server
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: 0.1.0-rc25
 dependencies:
   - name: common

--- a/charts/graph-proxy/values.yaml
+++ b/charts/graph-proxy/values.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
-argoServerUrl: http://workflows.diamond.ac.uk
+argoServerUrl: http://argo-workflows.workflows.diamond.ac.uk
 prefixPath: /graphql
 
 deployment:


### PR DESCRIPTION
I forgot to change this when migrating ingresses