### PR TITLE
fix: Bump graph proxy rust version from 1.80.1 to 1.83.0

### DIFF
--- a/graph-proxy/.devcontainer/Dockerfile
+++ b/graph-proxy/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/rust:1.80.1-bookworm
+FROM docker.io/library/rust:1.83.0-bookworm
 
 RUN rustup component add rustfmt clippy

--- a/graph-proxy/Dockerfile
+++ b/graph-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.80.1-bullseye AS build
+FROM docker.io/library/rust:1.83.0-bullseye AS build
 
 ARG ARGO_SERVER_SCHEMA_URL
 


### PR DESCRIPTION
This might fix some of the broken dependabot PR