### PR TITLE
Group `dependabot` updates for vite(st)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -56,5 +56,9 @@ updates:
         update-types:
           - patch
           - minor
+      vite:
+        patterns:
+          - vite
+          - vitest
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
The `vite` and `vitest` packages are tightly coupled and therefore need to be updated together, this ensures that `dependabot` will do so