### PR TITLE
Specify components & configure caching in Rust CI

### DIFF
--- a/.github/workflows/_graph_proxy_code.yaml
+++ b/.github/workflows/_graph_proxy_code.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
+          cache: false
           components: clippy,rustfmt
 
       - name: Cache Rust Build
@@ -55,6 +56,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
+          cache: false
           components: rustfmt
 
       - name: Cache Rust Build

--- a/.github/workflows/_graph_proxy_code.yaml
+++ b/.github/workflows/_graph_proxy_code.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+        with:
+          components: clippy,rustfmt
 
       - name: Cache Rust Build
         uses: Swatinem/rust-cache@v2.7.7
@@ -52,6 +54,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+        with:
+          components: rustfmt
 
       - name: Cache Rust Build
         uses: Swatinem/rust-cache@v2.7.7

--- a/.github/workflows/_graph_proxy_schema.yaml
+++ b/.github/workflows/_graph_proxy_schema.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
+          cache: false
           components: rustfmt
 
       - name: Cache Rust Build

--- a/.github/workflows/_graph_proxy_schema.yaml
+++ b/.github/workflows/_graph_proxy_schema.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+        with:
+          components: rustfmt
 
       - name: Cache Rust Build
         uses: Swatinem/rust-cache@v2.7.7


### PR DESCRIPTION
Explicitly specifies the `rustup` components required by each job and leaves cache configuration to the `rust-cache` step