### PR TITLE
Add MIME type field to artifact struct

### DIFF
--- a/graph-proxy/Cargo.lock
+++ b/graph-proxy/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "derive_more",
  "dotenvy",
  "lazy_static",
+ "mime_guess",
  "mockito",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1344,6 +1345,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2722,6 +2733,12 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/graph-proxy/Cargo.toml
+++ b/graph-proxy/Cargo.toml
@@ -31,6 +31,7 @@ derive_more = { version = "1.0.0", features = [
 ] }
 dotenvy = { version = "0.15.7" }
 lazy_static = { version = "1.5.0" }
+mime_guess = "2.0.5"
 opentelemetry = { version = "0.27.1" }
 opentelemetry-otlp = { version = "0.27.0", features = ["metrics"] }
 opentelemetry-semantic-conventions = "0.27.0"

--- a/graph-proxy/src/graphql/workflows.rs
+++ b/graph-proxy/src/graphql/workflows.rs
@@ -294,19 +294,7 @@ struct Artifact<'a> {
 impl Artifact<'_> {
     /// The file name of the artifact
     async fn name(&self) -> Result<&str, WorkflowParsingError> {
-        let path = Path::new(
-            self.manifest
-                .s3
-                .as_ref()
-                .ok_or(WorkflowParsingError::UnrecognisedArtifactStore)?
-                .key
-                .as_ref()
-                .ok_or(WorkflowParsingError::MissingArtifactKey)?,
-        );
-        path.file_name()
-            .unwrap_or_default()
-            .to_str()
-            .ok_or(WorkflowParsingError::InvalidArtifactFilename)
+        artifact_filename(self.manifest)
     }
 
     /// The download URL for the artifact
@@ -322,6 +310,32 @@ impl Artifact<'_> {
         ]);
         url
     }
+
+    /// The MIME type of the artifact data
+    async fn mime_type(&self) -> Result<&str, WorkflowParsingError> {
+        let filename = artifact_filename(self.manifest)?;
+        Ok(mime_guess::from_path(filename)
+            .first_raw()
+            .unwrap_or("application/octet-stream"))
+    }
+}
+
+fn artifact_filename(
+    manifest: &IoArgoprojWorkflowV1alpha1Artifact,
+) -> Result<&str, WorkflowParsingError> {
+    let path = Path::new(
+        manifest
+            .s3
+            .as_ref()
+            .ok_or(WorkflowParsingError::UnrecognisedArtifactStore)?
+            .key
+            .as_ref()
+            .ok_or(WorkflowParsingError::MissingArtifactKey)?,
+    );
+    path.file_name()
+        .unwrap_or_default()
+        .to_str()
+        .ok_or(WorkflowParsingError::InvalidArtifactFilename)
 }
 
 /// A Task created by a workflow
@@ -1196,6 +1210,72 @@ mod tests {
                         "artifacts": [{
                             "name": "main.log",
                             "url": expected_download_url
+                        }]
+                    }]
+                }
+            }
+        });
+        assert_eq!(resp.data.into_json().unwrap(), expected_data);
+    }
+
+    #[tokio::test]
+    async fn get_artifacts_mime_type_query() {
+        let workflow_name = "numpy-benchmark-wdkwj";
+        let visit = Visit {
+            proposal_code: "mg".to_string(),
+            proposal_number: 36964,
+            number: 1,
+        };
+
+        let mut server = mockito::Server::new_async().await;
+        let mut response_file_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        response_file_path.push("test-assets");
+        response_file_path.push("get-workflow-wdkwj.json");
+        let workflow_endpoint = server
+            .mock(
+                "GET",
+                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_file(response_file_path)
+            .create_async()
+            .await;
+
+        let argo_server_url = Url::parse(&server.url()).unwrap();
+        let schema = root_schema_builder()
+            .data(ArgoServerUrl(argo_server_url))
+            .data(None::<Authorization<Bearer>>)
+            .finish();
+        let query = format!(
+            r#"
+            query {{
+                workflow(name: "{}", visit: {{proposalCode: "{}", proposalNumber: {}, number: {}}}) {{
+                    status {{
+                        ...on WorkflowSucceededStatus {{
+                            tasks {{
+                                artifacts {{
+                                    name
+                                    mimeType
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        "#,
+            workflow_name, visit.proposal_code, visit.proposal_number, visit.number
+        );
+        let resp = schema.execute(query).await.into_result().unwrap();
+
+        workflow_endpoint.assert_async().await;
+        let expected_data = json!({
+            "workflow": {
+                "status": {
+                    "tasks": [{
+                        "artifacts": [{
+                            "name": "main.log",
+                            "mimeType": "text/plain"
                         }]
                     }]
                 }


### PR DESCRIPTION
This uses [mime_guess](https://docs.rs/mime_guess/latest/mime_guess/) to do a dumb guess of the MIME type based purely on the file extension.

[infer](https://docs.rs/infer/latest/infer/) has more stars on github, but I think it's being smarter and reading the file/bytes to determine the MIME type.

I didn't know if we wanted to bother to check the file data, so I chose the simpler option - feel free to suggest otherwise.