### PR TITLE
Make Rust binaries scannable with `cargo-auditable`

### DIFF
--- a/graph-proxy/Dockerfile
+++ b/graph-proxy/Dockerfile
@@ -4,7 +4,8 @@ ARG ARGO_SERVER_SCHEMA_URL
 
 WORKDIR /app
 
-RUN rustup component add rustfmt
+RUN rustup component add rustfmt \
+    && cargo install cargo-auditable
 
 COPY argo-workflows-openapi/Cargo.toml argo-workflows-openapi/Cargo.toml
 COPY argo-workflows-openapi/build.rs argo-workflows-openapi/build.rs
@@ -19,7 +20,7 @@ RUN mkdir src \
 COPY . .
 
 RUN touch src/main.rs \
-  && cargo build --release
+  && cargo auditable build --release
 
 FROM gcr.io/distroless/cc-debian12@sha256:b7550f0b15838de14c564337eef2b804ba593ae55d81ca855421bd52f19bb480 AS deploy
 

--- a/sessionspaces/Dockerfile
+++ b/sessionspaces/Dockerfile
@@ -4,6 +4,8 @@ ARG DATABASE_URL
 
 WORKDIR /app
 
+RUN cargo install cargo-auditable
+
 COPY Cargo.toml Cargo.lock ./
 
 RUN mkdir src && echo "fn main() {}" > src/main.rs \
@@ -13,7 +15,7 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs \
 COPY . .
 
 RUN touch src/main.rs \
-  && cargo build --release
+  && cargo auditable build --release
 
 FROM gcr.io/distroless/cc-debian12@sha256:b7550f0b15838de14c564337eef2b804ba593ae55d81ca855421bd52f19bb480 AS deploy
 


### PR DESCRIPTION
Compiles rust binaries in containers using `cargo-auditable` as described [in the dev portal](https://dev-portal.diamond.ac.uk/guide/rust/how-tos/auditable-builds/)