### PR TITLE
Update Rust service containers to use stable debian build images

### DIFF
--- a/graph-proxy/Dockerfile
+++ b/graph-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.84.1-bullseye AS build
+FROM docker.io/library/rust:1.84.1-bookworm AS build
 
 ARG ARGO_SERVER_SCHEMA_URL
 

--- a/sessionspaces/Dockerfile
+++ b/sessionspaces/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.84.1-bullseye AS build
+FROM docker.io/library/rust:1.84.1-bookworm AS build
 
 ARG DATABASE_URL
 


### PR DESCRIPTION
Not sure why we were using `bullseye` before, have been using `bookworm` for our dev-containers forever