### PR TITLE
fix(workflows): mutate workflow label on creation only

### DIFF
--- a/charts/sessionspaces/Chart.yaml
+++ b/charts/sessionspaces/Chart.yaml
@@ -3,7 +3,7 @@ name: sessionspaces
 description: Namespace controller for creating session namespaces
 type: application
 
-version: 0.3.7
+version: 0.3.8
 appVersion: 0.1.0-rc25
 dependencies:
   - name: common

--- a/charts/sessionspaces/values.yaml
+++ b/charts/sessionspaces/values.yaml
@@ -31,7 +31,6 @@ deployment:
 
 policy:
   create: true
-  runAsUser: 36055
 
 serviceAccount:
   create: true

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.13.4
+version: 0.13.5
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/templates/pod-gc-clusterpolicy.yaml
+++ b/charts/workflows/templates/pod-gc-clusterpolicy.yaml
@@ -10,6 +10,8 @@ spec:
         resources:
           kinds:
             - argoproj.io/*/Workflow
+          operations:
+            - CREATE
       mutate:
         patchStrategicMerge:
           spec:

--- a/charts/workflows/templates/workflow-label-clusterpolicy.yaml
+++ b/charts/workflows/templates/workflow-label-clusterpolicy.yaml
@@ -11,6 +11,8 @@ spec:
         resources:
           kinds:
             - argoproj.io/*/Workflow
+          operations:
+            - CREATE
       mutate:
         patchStrategicMerge:
           metadata:


### PR DESCRIPTION
By default, kyverno policies are triggered by both CREATE and CHANGE operations.

Since we have two policies in workflows that both mutate `kind: Workflow` one of the mutations can cause an additional mutation based on the "CHANGE". The `uid` in the label policy is attached to the `extra` field of the request and will only exists when the workflow is created, but NOT when the workflow resource has been changed. As a result, the POSIX uid label exists briefly (long enough for the first pod to read and run successfully) but disappears when the CHANGE mutation is applied because there is no uid in the extra field. 

Forcing the policy to only act on CREATE operations fixes this problem. 