### PR TITLE
Dependabot fix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,10 +16,9 @@ updates:
       prefix: "chore(deps)"
   - package-ecosystem: docker
     directories:
-      - /sessionspaces/
-      - /sessionspaces/.devcontainer/
-      - /graph-proxy/
-      - /graph-proxy/.devcontainer/
+      - /backend/
+      - /backend/sessionspaces/.devcontainer/
+      - /backend/graph-proxy/.devcontainer/
     schedule:
       interval: weekly
     groups:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -30,8 +30,7 @@ updates:
       prefix: "chore(deps)"
   - package-ecosystem: cargo
     directories:
-      - /sessionspaces/
-      - /graph-proxy/
+      - /backend/
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
Updating paths for dependabot since we restructured to `/backend`