### PR TITLE
Workflows with dev-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ vcluster connect workflows-cluster --silent -- <COMMAND>
 helm install workflows-cluster charts/workflows-cluster -f charts/workflows-cluster/dev-values.yaml
 ```
 
+If you wish to run workflows, you should override the `uid` in the workflows app with your own uid.
+
 ## Serve Docs
 
 Firstly, install `mkdocs` and the requisite dependencies in `docs/requirements.txt`; For this you may wish to use `pipx`, as:

--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -3,4 +3,4 @@ name: apps
 description: An argocd app to deploy apps inside the virtual cluster
 type: application
 
-version: 0.4.4
+version: 0.4.5

--- a/charts/apps/dev-values.yaml
+++ b/charts/apps/dev-values.yaml
@@ -1,5 +1,6 @@
 argocd:
   enabled: true
+  targetRevision: HEAD
   extraValueFiles:
     - dev-values.yaml
 
@@ -9,7 +10,8 @@ events:
     - dev-values.yaml
 
 groups:
-  enabled: true
+  enabled: false
+  targetRevision: HEAD
 
 kyverno:
   enabled: true
@@ -36,6 +38,7 @@ kyverno:
 
 sessionspaces:
   enabled: true
+  targetRevision: HEAD
   extraValueFiles:
     - dev-values.yaml
 
@@ -52,15 +55,18 @@ sealedsecrets:
 
 workflows:
   enabled: true
+  targetRevision: HEAD
   extraValueFiles:
     - dev-values.yaml
 
 graphProxy:
   enabled: true
+  targetRevision: HEAD
   extraValueFiles:
     - dev-values.yaml
 
 dashboard:
   enabled: true
+  targetRevision: HEAD
   extraValueFiles:
     - dev-values.yaml

--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.9.4
+version: 0.9.5
 
 dependencies:
   - name: common

--- a/charts/workflows-cluster/dev-values.yaml
+++ b/charts/workflows-cluster/dev-values.yaml
@@ -1,5 +1,9 @@
 vcluster:
   controlPlane:
+    distro:
+      k8s:
+        apiServer:
+          extraArgs: []
     backingStore:
       etcd:
         deploy:
@@ -27,6 +31,9 @@ vcluster:
             cpu: 100m
             memory: 250Mi
     statefulSet:
+      persistence:
+        addVolumes: []
+        addVolumeMounts: []
       highAvailability:
         replicas: 1
       resources:

--- a/charts/workflows-cluster/dev-values.yaml
+++ b/charts/workflows-cluster/dev-values.yaml
@@ -6,11 +6,11 @@ vcluster:
           statefulSet:
             resources:
               limits:
-                cpu: 200m
-                memory: 500Mi
+                cpu: 500m
+                memory: 5Gi
               requests:
-                cpu: 100m
-                memory: 250Mi
+                cpu: 500m
+                memory: 5Gi
             highAvailability:
               replicas: 1
             persistence:
@@ -31,11 +31,11 @@ vcluster:
         replicas: 1
       resources:
         limits:
-          cpu: 2
+          cpu: 2500m
           ephemeral-storage: 2Gi
           memory: 1Gi
         requests:
-          cpu: 2000m
+          cpu: 2500m
           memory: 500Mi
   experimental:
     deploy:

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.13.7
+version: 0.13.8
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/charts/s3mock/templates/deployment.yaml
+++ b/charts/workflows/charts/s3mock/templates/deployment.yaml
@@ -30,10 +30,6 @@ spec:
               protocol: TCP
               targetPort: {{ $.Values.bucketPort }}
               containerPort: {{ $.Values.bucketPort }}
-            - name: bucket-s
-              protocol: TCP
-              targetPort: {{ $.Values.bucketPortS }}
-              containerPort: {{ $.Values.bucketPortS }}
           resources:
             {{- $.Values.resources | toYaml | nindent 12 }}
           env:

--- a/charts/workflows/charts/s3mock/templates/service.yaml
+++ b/charts/workflows/charts/s3mock/templates/service.yaml
@@ -15,9 +15,5 @@ spec:
       port: 80
       targetPort: {{ $.Values.bucketPort }}
       protocol: TCP
-    - name: {{ include "common.names.fullname" $ }}-https
-      port: 443
-      targetPort: {{ $.Values.bucketPortS }}
-      protocol: TCP
 {{- end }}
 

--- a/charts/workflows/dev-values.yaml
+++ b/charts/workflows/dev-values.yaml
@@ -12,10 +12,10 @@ s3mock:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 1Gi
     limits:
       cpu: 200m
-      memory: 512Mi
+      memory: 1Gi
 
 argo-workflows:
   artifactRepository:

--- a/charts/workflows/dev-values.yaml
+++ b/charts/workflows/dev-values.yaml
@@ -44,6 +44,10 @@ argo-workflows:
         ephemeral-storage: 128Mi
   server:
     replicas: 1
+    authModes: ["server"]
+    extraEnv:
+      - name: ARGO_SECURE
+        value: "false"
     resources:
       limits:
         cpu: 100m

--- a/charts/workflows/dev-values.yaml
+++ b/charts/workflows/dev-values.yaml
@@ -22,16 +22,13 @@ argo-workflows:
     archiveLogs: true
     s3:
       accessKeySecret:
-        name: ""
-        key: ""
+        name: artifact-s3
+        key: access-key
       secretKeySecret:
-        name: ""
-        key: ""
-    endpoint:
-      valueFrom:
-        configMapKeyRef:
-          name: s3mock-configmap
-          key: endpoint
+        name: artifact-s3
+        key: secret-key
+      insecure: true
+      endpoint: workflows-s3mock.workflows.svc.cluster.local
     bucket: k8s-workflows-test
     region: unsupported
   controller:

--- a/charts/workflows/dev-values.yaml
+++ b/charts/workflows/dev-values.yaml
@@ -1,3 +1,4 @@
+uid: "some-uid"
 s3mock:
   enabled: true
   image:

--- a/charts/workflows/dev-values.yaml
+++ b/charts/workflows/dev-values.yaml
@@ -92,24 +92,4 @@ postgresql-ha:
     size: 5Gi
 
 oauth2-proxy:
-  replicaCount: 1
-  ingress:
-    enabled: false
-  redis:
-    master:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi
-    replica:
-      replicaCount: 0
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 200m
-      memory: 512Mi
+  enabled: false

--- a/charts/workflows/templates/artifact-s3-secret.yaml
+++ b/charts/workflows/templates/artifact-s3-secret.yaml
@@ -13,4 +13,14 @@ spec:
       name: artifact-s3
       namespace: workflows
     type: Opaque
+{{- else }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artifact-s3
+  namespace: workflows
+type: Opaque
+data:
+  access-key: dXNlcm5hbWU=
+  secret-key: cGFzc3dvcmQ=
 {{- end}}

--- a/charts/workflows/templates/workflow-label-clusterpolicy.yaml
+++ b/charts/workflows/templates/workflow-label-clusterpolicy.yaml
@@ -17,4 +17,8 @@ spec:
         patchStrategicMerge:
           metadata:
             labels:
+              {{- with .Values.uid }}
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ . }}'
+              {{- else }}
               workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra | "workflows.diamond.ac.uk/posixuid" | [0] }}` }}'
+              {{- end }}


### PR DESCRIPTION
This is quite a significant overhaul to the workflows engine in the dev deployment.
I have disabled auth etc for the vcluster and workflows, rather than mocking as the OIDC flow would require an ingress etc to be able to authenticate which isnt doable in the dev values.

Workflows is now running without any auth, and instead the UID should be set in values or over-written in the argo dashboard
Several tweaks have been made to the s3 config so it works with the mock credentials.