### PR TITLE
replace gprc with http for telemetry

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "built",
  "clap",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -224,7 +224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c95b41ba3c0f4ecccd73bf7e7aa7be3c41ff054968e988317bd9133ed210a4a2"
 dependencies = [
  "async-graphql",
- "axum 0.8.3",
+ "axum",
  "bytes",
  "futures-util",
  "serde_json",
@@ -331,38 +331,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -373,7 +346,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -391,26 +364,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -439,8 +392,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
- "axum 0.8.3",
- "axum-core 0.5.2",
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "headers",
@@ -1129,7 +1082,7 @@ dependencies = [
  "argo-workflows-openapi",
  "async-graphql",
  "async-graphql-axum",
- "axum 0.8.3",
+ "axum",
  "axum-extra",
  "chrono",
  "clap",
@@ -1845,12 +1798,6 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2131,14 +2078,10 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
- "base64 0.22.1",
- "hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "serde",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -3532,14 +3475,13 @@ version = "0.1.1"
 dependencies = [
  "built",
  "clap",
+ "mockito",
  "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "thiserror 2.0.12",
  "tokio",
- "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3791,12 +3733,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3806,7 +3745,6 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ derive_more = { version = "1.0.0", features = [
     "into",
 ] }
 dotenvy = { version = "0.15.7" }
+mockito = { version = "1.7.0" }
 reqwest = { version = "0.12.15", default-features = false, features = [
     "rustls-tls",
     "json",

--- a/backend/graph-proxy/Cargo.toml
+++ b/backend/graph-proxy/Cargo.toml
@@ -30,4 +30,4 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-mockito = "1.7.0"
+mockito = { workspace = true }

--- a/backend/telemetry/Cargo.toml
+++ b/backend/telemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "telemetry"
 build = "build.rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A telemetry library for collecting and exporting metrics and traces."

--- a/backend/telemetry/Cargo.toml
+++ b/backend/telemetry/Cargo.toml
@@ -19,9 +19,8 @@ tracing-subscriber = { version = "0.3.19" }
 url = { workspace = true }
 
 [dev-dependencies]
-opentelemetry-proto = { version = "0.29.0" }
 tokio = { workspace = true }
-tonic = { version = "0.12.3" }
+mockito = { version = "1.7.0" }
 
 [build-dependencies]
 built = { version = "0.7.5" }

--- a/backend/telemetry/Cargo.toml
+++ b/backend/telemetry/Cargo.toml
@@ -20,7 +20,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-mockito = { version = "1.7.0" }
+mockito = { workspace = true }
 
 [build-dependencies]
 built = { version = "0.7.5" }

--- a/backend/telemetry/src/lib.rs
+++ b/backend/telemetry/src/lib.rs
@@ -125,75 +125,31 @@ pub fn setup_telemetry(config: TelemetryConfig) -> Result<OtelGuard, TelemetryEr
 #[cfg(test)]
 mod tests {
     use super::{setup_telemetry, TelemetryConfig};
-    use opentelemetry_proto::tonic::collector::{
-        metrics::v1::{
-            metrics_service_server::{MetricsService, MetricsServiceServer},
-            ExportMetricsServiceRequest, ExportMetricsServiceResponse,
-        },
-        trace::v1::{
-            trace_service_server::{TraceService, TraceServiceServer},
-            ExportTraceServiceRequest, ExportTraceServiceResponse,
-        },
-    };
-    use std::sync::{Arc, Mutex};
-    use tonic::{transport::Server, Request, Response, Status};
+    use mockito::{Mock, Server};
     use tracing::Level;
     use url::Url;
 
-    #[derive(Debug, Default)]
-    struct MockMetricsService {
-        requests: Arc<Mutex<Vec<ExportMetricsServiceRequest>>>,
-    }
-
-    #[tonic::async_trait]
-    impl MetricsService for MockMetricsService {
-        async fn export(
-            &self,
-            request: Request<ExportMetricsServiceRequest>,
-        ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
-            self.requests.lock().unwrap().push(request.into_inner());
-            Ok(Response::new(ExportMetricsServiceResponse::default()))
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct MockTraceService {
-        requests: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
-    }
-
-    #[tonic::async_trait]
-    impl TraceService for MockTraceService {
-        async fn export(
-            &self,
-            request: Request<ExportTraceServiceRequest>,
-        ) -> Result<Response<ExportTraceServiceResponse>, Status> {
-            self.requests.lock().unwrap().push(request.into_inner());
-            Ok(Response::new(ExportTraceServiceResponse::default()))
-        }
-    }
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_metrics_export() {
-        let metrics_requests = Arc::new(Mutex::new(Vec::new()));
-        let metrics_service = MockMetricsService {
-            requests: metrics_requests.clone(),
-        };
-        let trace_requests = Arc::new(Mutex::new(Vec::new()));
-        let trace_service = MockTraceService {
-            requests: trace_requests.clone(),
-        };
-        let addr = "[::1]:50051".parse().unwrap();
-        let server = Server::builder()
-            .add_service(MetricsServiceServer::new(metrics_service))
-            .add_service(TraceServiceServer::new(trace_service))
-            .serve(addr);
-
-        tokio::spawn(async move {
-            server.await.unwrap();
-        });
+        let mut server = Server::new_async().await;
+        let metrics_mock: Mock = server
+            .mock("POST", "/v1/metrics")
+            .match_header("content-type", "application/x-protobuf")
+            .with_status(200)
+            .with_body("OK")
+            .create_async()
+            .await;
+        let traces_mock: Mock = server
+            .mock("POST", "/v1/traces")
+            .match_header("content-type", "application/x-protobuf")
+            .with_status(200)
+            .with_body("OK")
+            .create_async()
+            .await;
+        let base_url = server.url();
         let config = TelemetryConfig {
-            metrics_endpoint: Some(Url::parse("http://[::1]:50051").unwrap()),
-            tracing_endpoint: Some(Url::parse("http://[::1]:50051").unwrap()),
+            metrics_endpoint: Some(Url::parse(&format!("{}/v1/metrics", base_url)).unwrap()),
+            tracing_endpoint: Some(Url::parse(&format!("{}/v1/traces", base_url)).unwrap()),
             telemetry_level: Level::INFO,
         };
         {
@@ -201,9 +157,8 @@ mod tests {
             tracing::info!(monotonic_counter.test_metric = 1u64, "Test metric");
             tracing::info_span!("test_span");
         }
-        let metrics_requests = metrics_requests.lock().unwrap();
-        let trace_requests = trace_requests.lock().unwrap();
-        assert!(!metrics_requests.is_empty(), "No metrics were exported");
-        assert!(!trace_requests.is_empty(), "No traces were exported");
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        metrics_mock.assert_async().await;
+        traces_mock.assert_async().await;
     }
 }

--- a/backend/telemetry/src/lib.rs
+++ b/backend/telemetry/src/lib.rs
@@ -77,7 +77,7 @@ pub fn setup_telemetry(config: TelemetryConfig) -> Result<OtelGuard, TelemetryEr
 
     let (meter_provider, metrics_layer) = if let Some(metrics_endpoint) = config.metrics_endpoint {
         let exporter = MetricExporter::builder()
-            .with_tonic()
+            .with_http()
             .with_endpoint(metrics_endpoint)
             .build()?;
         let meter_provider = SdkMeterProvider::builder()
@@ -94,7 +94,7 @@ pub fn setup_telemetry(config: TelemetryConfig) -> Result<OtelGuard, TelemetryEr
 
     let (tracer_provider, tracing_layer) = if let Some(tracing_endpoint) = config.tracing_endpoint {
         let exporter = SpanExporter::builder()
-            .with_tonic()
+            .with_http()
             .with_endpoint(tracing_endpoint)
             .build()?;
         let tracer_provider = SdkTracerProvider::builder()


### PR DESCRIPTION
Since we are gonna use ingress to send telemetry outside the vitrual cluster, our ingress controller is not handling grpc to http (HTTP/2 vs HTTP/1)  conversion properly. It's worth replacing our telemtry with http since we are using ingress anyway. 