### PR TITLE
configure tracing and ingress for telemetry

### DIFF
--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A monitoring stack for the workflows deployment
 type: application
-version: 0.1.1
+version: 0.1.2
 dependencies:
   - name: grafana
     repository: https://grafana.github.io/helm-charts

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -390,6 +390,15 @@ opentelemetry-collector:
                 - source_labels: [__meta_kubernetes_pod_node_name]
                   action: replace
                   target_label: node
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+            cors:
+              allowed_origins:
+                - "*"
     exporters:
       prometheus:
         endpoint: 0.0.0.0:9090
@@ -398,6 +407,7 @@ opentelemetry-collector:
         metrics:
           receivers:
             - prometheus
+            - otlp
           processors:
             - memory_limiter
             - batch

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -290,8 +290,8 @@ opentelemetry-collector:
   ingress:
     enabled: true
     annotations:
-        kubernetes.io/ingressClassName: nginx
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      kubernetes.io/ingressClassName: nginx
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     hosts:
       - host: otelcollector.workflows.diamond.ac.uk
         paths:
@@ -396,9 +396,6 @@ opentelemetry-collector:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-            cors:
-              allowed_origins:
-                - "*"
     exporters:
       prometheus:
         endpoint: 0.0.0.0:9090

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -402,6 +402,14 @@ opentelemetry-collector:
     exporters:
       prometheus:
         endpoint: 0.0.0.0:9090
+      otlphttp:
+        endpoint: "https://otel.tracing.diamond.ac.uk:4318"
+        timeout: 30s
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 5m
     service:
       pipelines:
         metrics:
@@ -413,3 +421,12 @@ opentelemetry-collector:
             - batch
           exporters:
             - prometheus
+            - otlphttp
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - otlphttp

--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -287,6 +287,21 @@ opentelemetry-collector:
       enabled: false
     zipkin:
       enabled: false
+  ingress:
+    enabled: true
+    annotations:
+        kubernetes.io/ingressClassName: nginx
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    hosts:
+      - host: otelcollector.workflows.diamond.ac.uk
+        paths:
+          - path: '/'
+            pathType: Prefix
+            port: 4318
+    tls:
+      - secretName: letsencrypt-otelcollector-workflows-diamond-ac-uk
+        hosts:
+          - otelcollector.workflows.diamond.ac.uk
   resources:
     requests:
       cpu: '8'


### PR DESCRIPTION
After discussing with the cloud team, agreed to use the centralized tracing. 

The cloud team now have a centralized metrics/tracing solution agreed by Garry before he left. So we connect our otel collector to the centralized otel collector which is still under development, but should be done in a week. 

The traces can be viewed at [https://tracing.diamond.ac.uk/](https://tracing.diamond.ac.uk)