### PR TITLE
fix(graph-proxy): fix incorrect dir in exclude config

### DIFF
--- a/backend/graph-proxy/Cargo.toml
+++ b/backend/graph-proxy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graph-proxy"
 version = "0.1.3"
 edition = "2021"
-exclude = ["test-resources/"]
+exclude = ["test-assets/"]
 license-file = "../../LICENSE"
 
 [dependencies]


### PR DESCRIPTION
I randomly noticed this recently. The dir name was changed back in https://github.com/DiamondLightSource/workflows/pull/375 but I neglected to change the config accordingly, my bad!