### PR TITLE
feat(graph-proxy): increase the limit on requested workflows

### DIFF
--- a/backend/graph-proxy/src/graphql/workflows.rs
+++ b/backend/graph-proxy/src/graphql/workflows.rs
@@ -637,7 +637,7 @@ impl WorkflowsQuery {
         ctx: &Context<'_>,
         visit: VisitInput,
         cursor: Option<String>,
-        #[graphql(validator(minimum = 1, maximum = 10))] limit: Option<u32>,
+        #[graphql(validator(minimum = 1, maximum = 30))] limit: Option<u32>,
         filter: Option<WorkflowFilter>,
     ) -> anyhow::Result<Connection<OpaqueCursor<usize>, Workflow, EmptyFields, EmptyFields>> {
         let mut url = ctx.data_unchecked::<ArgoServerUrl>().deref().to_owned();


### PR DESCRIPTION
30 seemed reasonable, does anyone have any input? Maybe 40/50?