### PR TITLE
fix(release-please): cargo-workspace does not support subdirs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,10 +11,6 @@
       "type": "node-workspace",
       "updateAllPackages": false,
       "updatePeerDependencies": true
-    }, 
-    {
-      "type": "cargo-workspace",
-      "updateAllPackages": false
     }
   ],
   "packages": {


### PR DESCRIPTION
removing cargo-workspace plugin from release-please config. It seems to expect a Cargo.toml at the root of the monorepo and there is no option to provide a different path.