### PR TITLE
feat(dashboard): added navigation to header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ kubeconfig.yaml
 
 # Relay
 __generated__
+supergraph.graphql
 
 # File Types
 **/*.tgz # Chart files created when deploying helm dep build

--- a/frontend/dashboard/src/routes/Dashboard.tsx
+++ b/frontend/dashboard/src/routes/Dashboard.tsx
@@ -117,9 +117,7 @@ const argoCdCard = (
 function Dashboard() {
   return (
     <ThemeProvider theme={DiamondTheme} defaultMode="light">
-      <WorkflowsNavbar
-        title={"Workflows at Diamond"}
-      ></WorkflowsNavbar>
+      <WorkflowsNavbar />
       <Container maxWidth="sm" sx={{ mt: 5, mb: 4 }}>
         <Grid
           container

--- a/frontend/dashboard/src/routes/TemplatesList.tsx
+++ b/frontend/dashboard/src/routes/TemplatesList.tsx
@@ -7,7 +7,7 @@ const TemplatesList: React.FC = () => {
   return (
     <>
       <ThemeProvider theme={DiamondTheme} defaultMode="light">
-        <WorkflowsNavbar title="Templates" />
+        <WorkflowsNavbar />
         <Breadcrumbs path={window.location.pathname} />
         <Container maxWidth="sm">
           <Box display="flex" flexDirection="column" alignItems="center" mt={2}>

--- a/frontend/dashboard/src/routes/templateview.tsx
+++ b/frontend/dashboard/src/routes/templateview.tsx
@@ -1,13 +1,16 @@
-import { Container, Box } from "@mui/material";
-import { ThemeProvider, DiamondTheme, Breadcrumbs } from "@diamondlightsource/sci-react-ui";
 import { useParams } from "react-router-dom";
+import { Container, Box  } from "@mui/material";
+import {
+  ThemeProvider,
+  DiamondTheme,
+  Breadcrumbs,
+} from "@diamondlightsource/sci-react-ui";
 import WorkflowsNavbar from "workflows-lib/lib/components/workflow/WorkflowsNavbar";
 import TemplateView from "relay-workflows-lib/lib/components/TemplateView";
 import WorkflowsErrorBoundary from "workflows-lib/lib/components/workflow/WorkflowsErrorBoundary";
 import { Suspense } from "react";
 const TemplatesView: React.FC = () => {
   const { templateName } = useParams<{ templateName: string }>();
-
   return (
     <>
       <ThemeProvider theme={DiamondTheme} defaultMode="light">

--- a/frontend/dashboard/src/routes/workflows.tsx
+++ b/frontend/dashboard/src/routes/workflows.tsx
@@ -13,7 +13,6 @@ function WorkflowsSelect() {
   return (
     <ThemeProvider theme={DiamondTheme} defaultMode="light">
       <WorkflowsNavbar
-        title={"Instrument Session Selection"}
         sessionInfo={"No Instrument Session Selected"}
       />
       <Breadcrumbs path={window.location.pathname} />

--- a/frontend/dashboard/src/routes/workflowslist.tsx
+++ b/frontend/dashboard/src/routes/workflowslist.tsx
@@ -22,7 +22,6 @@ const WorkflowsList: React.FC = () => {
     <>
       <ThemeProvider theme={DiamondTheme} defaultMode="light">
         <WorkflowsNavbar
-          title="Submitted Workflows"
           sessionInfo={`Instrument Session ID is ${visitid?? ""}`}
         />
         <Breadcrumbs path={window.location.pathname} />

--- a/frontend/dashboard/src/routes/workflowview.tsx
+++ b/frontend/dashboard/src/routes/workflowview.tsx
@@ -24,7 +24,6 @@ function WorkflowView() {
   return (
     <ThemeProvider theme={DiamondTheme} defaultMode="light">
       <WorkflowsNavbar
-        title={"Workflow Information"}
         sessionInfo={`Instrument Session ID is ${visitid?? ""}`}
       />
       <Breadcrumbs path={window.location.pathname} />

--- a/frontend/workflows-lib/lib/components/workflow/WorkflowsNavbar.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/WorkflowsNavbar.tsx
@@ -2,12 +2,10 @@ import { Box, Typography } from "@mui/material";
 import { Navbar, DiamondTheme, NavLinks, NavLink } from "@diamondlightsource/sci-react-ui";
 
 interface WorkflowsNavbarProps {
-  title?: string;
   sessionInfo?: string;
 }
 
 const WorkflowsNavbar: React.FC<WorkflowsNavbarProps> = ({
-  title,
   sessionInfo,
 }) => (
   <Navbar logo="theme">

--- a/frontend/workflows-lib/lib/components/workflow/WorkflowsNavbar.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/WorkflowsNavbar.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography } from "@mui/material";
-import { Navbar, DiamondTheme } from "@diamondlightsource/sci-react-ui";
+import { Navbar, DiamondTheme, NavLinks, NavLink } from "@diamondlightsource/sci-react-ui";
 
 interface WorkflowsNavbarProps {
   title?: string;
@@ -11,27 +11,24 @@ const WorkflowsNavbar: React.FC<WorkflowsNavbarProps> = ({
   sessionInfo,
 }) => (
   <Navbar logo="theme">
-    <>
-      {title ? (
-        <Box sx={{ flexGrow: 1, display: "flex", justifyContent: "right" }}>
-          <Typography
-            sx={{
-              color: DiamondTheme.palette.primary.contrastText,
-              fontSize: "h1",
-            }}
-          >
-            {title}
-          </Typography>
-        </Box>
-      ) : null}
-      {sessionInfo ? (
-        <Box sx={{ flexGrow: 1, display: "flex", justifyContent: "flex-end" }}>
-          <Typography sx={{ color: DiamondTheme.palette.primary.contrastText }}>
-            {sessionInfo}
-          </Typography>
-        </Box>
-      ) : null}
-    </>
+    <Box sx={{ flexGrow: 1, display: "flex", justifyContent: "right" }}>
+      <NavLinks>
+        <NavLink href="/">
+           Home
+        </NavLink>
+          <NavLink href="/workflows">
+           Workflows
+        </NavLink>
+          <NavLink href="/templates">
+           Templates
+        </NavLink>
+      </NavLinks>
+    </Box>
+    <Box sx={{ flexGrow: 1, display: "flex", justifyContent: "flex-end" }}>
+      <Typography sx={{ color: DiamondTheme.palette.primary.contrastText }}>
+        {sessionInfo}
+      </Typography>
+    </Box>
   </Navbar>
 );
 

--- a/frontend/workflows-lib/tests/components/WorkflowsNavbar.test.tsx
+++ b/frontend/workflows-lib/tests/components/WorkflowsNavbar.test.tsx
@@ -7,17 +7,14 @@ import WorkflowsNavbar from '../../lib/components/workflow/WorkflowsNavbar';
 
 describe('WorkflowsNavbar', () => {
   it('renders with title and sessionInfo', () => {
-    const { getByText } = render(<WorkflowsNavbar title="Homepage" sessionInfo="cm12345-6" />);
-    expect(getByText('Homepage')).toBeInTheDocument();
+    const { getByText } = render(<WorkflowsNavbar sessionInfo="cm12345-6" />);
     expect(getByText('cm12345-6')).toBeInTheDocument();
   });
 
   it('applies the correct styles', () => {
-    const { getByText } = render(<WorkflowsNavbar title="Styled Homepage" sessionInfo="cm34567-8" />);
-    const titleElement = getByText('Styled Homepage');
+    const { getByText } = render(<WorkflowsNavbar sessionInfo="cm34567-8" />);
     const sessionElement = getByText('cm34567-8');
 
-    expect(titleElement).toHaveStyle(`color: ${DiamondTheme.palette.primary.contrastText}`);
     expect(sessionElement).toHaveStyle(`color: ${DiamondTheme.palette.primary.contrastText}`);
   });
 });


### PR DESCRIPTION
I've added a basic nav bar to the header,
Let me know if this is what you had in mind. I've dropped the "title" section in favor of this - Its still a parameter in the nav bar function but I will remove all mentions of it but I will remove the references to it if  you're happy with this.

We probably need to have a slightly different approach to the formatting of the session part of the header as this moves the title, depending on which pages do/don't have it