### PR TITLE
ci: lint example workflows

### DIFF
--- a/.github/workflows/_lint_workflows.yaml
+++ b/.github/workflows/_lint_workflows.yaml
@@ -1,0 +1,46 @@
+name: Lint workflow templates
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4.2.2
+
+      - name: Mock kubectl config
+        run: |
+          mkdir -p ~/.kube
+          cat <<EOF > ~/.kube/config
+          apiVersion: v1
+          kind: Config
+          preferences: {}
+          current-context: user@cluster
+          clusters:
+            - name: cluster
+              cluster:
+                server: https://url.co.uk
+          contexts:
+            - name: user@cluster
+              context:
+                cluster: cluster
+                user: user
+          users:
+            - name: user
+              user:
+                token: dummy-token
+          EOF
+
+      - name: Install ArgoCLI
+        run: |
+          curl -sLO "https://github.com/argoproj/argo-workflows/releases/download/v3.6.7/argo-linux-amd64.gz"
+          gunzip "argo-linux-amd64.gz"
+          chmod +x "argo-linux-amd64"
+          mv "./argo-linux-amd64" /usr/local/bin/argo
+          argo version
+
+      - name: Lint files
+        run: |
+          argo lint examples

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,3 +114,7 @@ jobs:
     # Deduplicate jobs from pull requests and branch pushes within the same repo.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/_dev_resources.yaml
+
+  lint_workflows:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    uses: ./.github/workflows/_lint_workflows.yaml


### PR DESCRIPTION
Simple CI to lint workflow templates,
It's not very pretty - particularly the kubeconfig part but the argo CLI insists on having one to run. There wasn't a premade action for this so it might be nice to make one, and a bit prettier than having this in the group/beamline examples repos