### PR TITLE
Restrict UI parameters

### DIFF
--- a/backend/graph-proxy/src/graphql/parameter_schema.rs
+++ b/backend/graph-proxy/src/graphql/parameter_schema.rs
@@ -147,7 +147,9 @@ impl ArgumentSchema {
         let mut arguments_schema = ArgumentSchema::default();
         if let Some(arguments) = &spec.arguments {
             for parameter in arguments.parameters.clone() {
-                arguments_schema.add_parameter(&parameter, annotations)?;
+                if parameter.value_from.is_none() {
+                    arguments_schema.add_parameter(&parameter, annotations)?;
+                }
             }
         }
         if let Some(entrypoint) = &spec.entrypoint {
@@ -159,7 +161,9 @@ impl ArgumentSchema {
             }) {
                 if let Some(inputs) = &template.inputs {
                     for parameter in &inputs.parameters {
-                        arguments_schema.add_parameter(parameter, annotations)?;
+                        if parameter.value_from.is_none() {
+                            arguments_schema.add_parameter(parameter, annotations)?;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Dont show parameters from configmap when no Json form is provided
The API reference for `valueFrom` is [here](https://argo-workflows.readthedocs.io/en/latest/fields/#valuefrom), I dont see why any of these should appear in  the UI but we can revisit if a usecase surfaces