### PR TITLE
fix(graph-proxy): increase limit for workflow templates

### DIFF
--- a/backend/graph-proxy/src/graphql/workflow_templates.rs
+++ b/backend/graph-proxy/src/graphql/workflow_templates.rs
@@ -113,7 +113,7 @@ impl WorkflowTemplatesQuery {
         &self,
         ctx: &Context<'_>,
         cursor: Option<String>,
-        #[graphql(validator(minimum = 1, maximum = 10))] limit: Option<u32>,
+        #[graphql(validator(minimum = 1, maximum = 100))] limit: Option<u32>,
         filter: Option<WorkflowTemplatesFilter>,
     ) -> anyhow::Result<Connection<OpaqueCursor<usize>, WorkflowTemplate, EmptyFields, EmptyFields>>
     {
@@ -123,7 +123,7 @@ impl WorkflowTemplatesQuery {
         url.path_segments_mut()
             .unwrap()
             .extend(["api", "v1", "cluster-workflow-templates"]);
-        let limit = limit.unwrap_or(10);
+        let limit = limit.unwrap_or(100);
         url.query_pairs_mut()
             .append_pair("listOptions.limit", &limit.to_string());
 


### PR DESCRIPTION
Depending on our conclusions about the cursor, it may be worth removing the `limit` field altogether