### PR TITLE
feat(frontend): report errors/success on template submission

### DIFF
--- a/frontend/dashboard/src/routes/SingleTemplatePage.tsx
+++ b/frontend/dashboard/src/routes/SingleTemplatePage.tsx
@@ -11,8 +11,14 @@ const SingleTemplatePage: React.FC = () => {
     <>
       <WorkflowsNavbar />
       <Breadcrumbs path={window.location.pathname} />
-      <Container maxWidth="sm">
-        <Box display="flex" flexDirection="column" alignItems="center" mt={2}>
+      <Container maxWidth="md">
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          mt={2}
+          mb={10}
+        >
           <WorkflowsErrorBoundary>
             <Suspense>
               {templateName ? (

--- a/frontend/workflows-lib/lib/components/workflow/SubmittedMessagesList.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/SubmittedMessagesList.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Box,
+  Divider,
+  Paper,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Link } from "react-router-dom";
+import {
+  SubmissionGraphQLErrorMessage,
+  SubmissionNetworkErrorMessage,
+  SubmissionSuccessMessage,
+} from "../../types";
+
+const renderSubmittedMessage = (
+  r:
+    | SubmissionGraphQLErrorMessage
+    | SubmissionNetworkErrorMessage
+    | SubmissionSuccessMessage,
+  i: number,
+) => {
+  switch (r.type) {
+    case "success":
+      return (
+        <Accordion
+          key={`success-${String(i)}`}
+          disableGutters
+          onChange={() => {}}
+        >
+          <AccordionSummary>
+            <Typography>
+              Successfully submitted{" "}
+              <Link
+                to={`/workflows/${r.message}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {r.message}
+              </Link>
+            </Typography>
+          </AccordionSummary>
+        </Accordion>
+      );
+
+    case "networkError":
+      return (
+        <Accordion key={`error-msg-${String(i)}`}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography sx={{ color: "red" }}>
+              Submission error type {r.error.name}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>Submission error message {r.error.message}</Typography>
+          </AccordionDetails>
+        </Accordion>
+      );
+    case "graphQLError":
+    default:
+      return (
+        <Accordion key={`errors-${String(i)}`}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography sx={{ color: "red" }}>
+              Submission error type GraphQL
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            {r.errors.map((e, j) => {
+              return (
+                <Typography key={`errors-msgs-${String(j)}`}>
+                  Error {j} {e.message}
+                </Typography>
+              );
+            })}
+          </AccordionDetails>
+        </Accordion>
+      );
+  }
+};
+
+interface SubmittedMessagesListProps {
+  submissionResults: (
+    | SubmissionGraphQLErrorMessage
+    | SubmissionNetworkErrorMessage
+    | SubmissionSuccessMessage
+  )[];
+}
+
+const SubmittedMessagesList: React.FC<SubmittedMessagesListProps> = ({
+  submissionResults,
+}) => {
+  return (
+    <Box
+      sx={{
+        width: {
+          xl: "100%",
+          lg: "100%",
+          md: "90%",
+          sm: "80%",
+          xs: "70%",
+        },
+        maxWidth: "1200px",
+        height: "100%",
+        mx: "auto",
+      }}
+    >
+      <Divider sx={{ mt: 5, mb: 5 }} />
+      {submissionResults.length > 0 && (
+        <>
+          <Paper elevation={1} sx={{ p: 2 }}>
+            <Typography variant="h6" sx={{ textAlign: "center" }}>
+              Submissions
+            </Typography>
+          </Paper>
+          {submissionResults.map((r, i) => renderSubmittedMessage(r, i))}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default SubmittedMessagesList;

--- a/frontend/workflows-lib/lib/main.ts
+++ b/frontend/workflows-lib/lib/main.ts
@@ -3,4 +3,5 @@ export { default as TasksFlow } from "./components/workflow/TasksFlow";
 export { default as TasksTable } from "./components/workflow/TasksTable";
 export { default as SubmissionForm } from "./components/template/SubmissionForm";
 export { default as TemplateCard } from "./components/template/TemplateCard";
+export { default as SubmittedMessagesList } from "./components/workflow/SubmittedMessagesList";
 export * from "./types";

--- a/frontend/workflows-lib/lib/types.ts
+++ b/frontend/workflows-lib/lib/types.ts
@@ -1,3 +1,5 @@
+import { PayloadError } from "relay-runtime";
+
 export type TaskStatus =
   | "PENDING"
   | "RUNNING"
@@ -54,5 +56,20 @@ export interface Template {
 }
 
 export interface WorkflowQueryFilter {
-  creator?: string,
+  creator?: string;
 }
+
+export interface SubmissionSuccessMessage {
+  type: "success";
+  message: string;
+}
+
+export interface SubmissionNetworkErrorMessage {
+  type: "networkError";
+  error: Error;
+};
+
+export interface SubmissionGraphQLErrorMessage {
+  type: "graphQLError";
+  errors: PayloadError[];
+};


### PR DESCRIPTION
On template submission, populates an accordion list with either error info or successfully submitted workflow name (with link to workflow page).

I put the submission message types in the workflows lib even though they have a relay import (for PayloadError). I can move this into the relay lib if we think it fits there better.