### PR TITLE
feat(frontend): add rerun template from submitted workflow

### DIFF
--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -31,15 +31,19 @@ const router = createBrowserRouter([
     element: <SingleTemplatePage />,
   },
   {
+    path: "templates/:templateName/:prepopulate",
+    element: <SingleTemplatePage />,
+  },
+  {
     path: "workflows/:visitid",
     element: <WorkflowsListPage />,
   },
   {
-    path: "workflows/:visitid/:workflowname",
+    path: "workflows/:visitid/:workflowName",
     element: <SingleWorkflowPage />,
   },
   {
-    path: "workflows/:visitid/:workflowname/:taskname",
+    path: "workflows/:visitid/:workflowName/:taskname",
     element: <SingleWorkflowPage />,
   },
 ]);

--- a/frontend/dashboard/src/routes/SingleTemplatePage.tsx
+++ b/frontend/dashboard/src/routes/SingleTemplatePage.tsx
@@ -1,12 +1,28 @@
-import { useParams } from "react-router-dom";
-import { Container, Box } from "@mui/material";
+import { useParams, NavLink } from "react-router-dom";
+import { Container, Box, Typography } from "@mui/material";
 import { Breadcrumbs } from "@diamondlightsource/sci-react-ui";
 import WorkflowsNavbar from "workflows-lib/lib/components/workflow/WorkflowsNavbar";
 import TemplateView from "relay-workflows-lib/lib/components/TemplateView";
+import TemplateViewRetrigger from "relay-workflows-lib/lib/components/TemplateViewRetrigger";
+
 import WorkflowsErrorBoundary from "workflows-lib/lib/components/workflow/WorkflowsErrorBoundary";
 import { Suspense } from "react";
+import {
+  parseVisitAndTemplate,
+  visitToText,
+} from "workflows-lib/lib/utils/commonUtils";
+
 const SingleTemplatePage: React.FC = () => {
-  const { templateName } = useParams<{ templateName: string }>();
+  const { templateName, prepopulate } = useParams<{
+    templateName: string;
+    prepopulate?: string;
+  }>();
+
+  const [visit, workflowName] = parseVisitAndTemplate(prepopulate ?? "") ?? [
+    undefined,
+    undefined,
+  ];
+
   return (
     <>
       <WorkflowsNavbar />
@@ -19,13 +35,29 @@ const SingleTemplatePage: React.FC = () => {
           mt={2}
           mb={10}
         >
-          <WorkflowsErrorBoundary>
-            <Suspense>
-              {templateName ? (
-                <TemplateView templateName={templateName} />
-              ) : null}
-            </Suspense>
-          </WorkflowsErrorBoundary>
+          {workflowName && (
+            <Typography align="center" mb={5}>
+              Using initial parameters from{" "}
+              <NavLink to={`/workflows/${visitToText(visit)}/${workflowName}`}>
+                {workflowName}
+              </NavLink>
+            </Typography>
+          )}
+          {templateName && (
+            <WorkflowsErrorBoundary>
+              <Suspense>
+                {workflowName ? (
+                  <TemplateViewRetrigger
+                    templateName={templateName}
+                    workflowName={workflowName}
+                    visit={visit}
+                  />
+                ) : (
+                  <TemplateView templateName={templateName} />
+                )}
+              </Suspense>
+            </WorkflowsErrorBoundary>
+          )}
         </Box>
       </Container>
     </>

--- a/frontend/dashboard/src/routes/SingleWorkflowPage.tsx
+++ b/frontend/dashboard/src/routes/SingleWorkflowPage.tsx
@@ -9,9 +9,9 @@ import WorkflowsErrorBoundary from "workflows-lib/lib/components/workflow/Workfl
 import WorkflowsNavbar from "workflows-lib/lib/components/workflow/WorkflowsNavbar";
 
 function SingleWorkflowPage() {
-  const { visitid, workflowname, taskname } = useParams<{
+  const { visitid, workflowName, taskname } = useParams<{
     visitid: string;
-    workflowname: string;
+    workflowName: string;
     taskname?: string;
   }>();
 
@@ -23,14 +23,14 @@ function SingleWorkflowPage() {
         sessionInfo={`Instrument Session ID is ${visitid ?? ""}`}
       />
       <Breadcrumbs path={window.location.pathname} />
-      {visit && workflowname ? (
+      {visit && workflowName ? (
         <Container maxWidth="lg">
           <Box display="flex" flexDirection="column" alignItems="center" mt={2}>
             <WorkflowsErrorBoundary>
               <Suspense>
                 <SingleWorkflowView
                   visit={visit}
-                  workflowname={workflowname}
+                  workflowName={workflowName}
                   taskname={taskname}
                 />
               </Suspense>

--- a/frontend/relay-workflows-lib/lib/components/RetriggerWorkflow.tsx
+++ b/frontend/relay-workflows-lib/lib/components/RetriggerWorkflow.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import { graphql } from "relay-runtime";
+import { RetriggerWorkflowQuery as RetriggerWorkflowQueryType } from "./__generated__/RetriggerWorkflowQuery.graphql";
+import { Visit } from "@diamondlightsource/sci-react-ui";
+
+import { useLazyLoadQuery } from "react-relay/hooks";
+import { NavLink } from "react-router-dom";
+import { visitToText } from "workflows-lib/lib/utils/commonUtils";
+import Tooltip from "@mui/material/Tooltip";
+
+const retriggerWorkflowQuery = graphql`
+  query RetriggerWorkflowQuery($visit: VisitInput!, $workflowname: String!) {
+    workflow(visit: $visit, name: $workflowname) {
+      templateRef
+    }
+  }
+`;
+interface RetriggerWorkflowProps {
+  instrumentSession: Visit;
+  workflowName: string;
+}
+
+const RetriggerWorkflow: React.FC<RetriggerWorkflowProps> = ({
+  instrumentSession,
+  workflowName,
+}) => {
+  const data = useLazyLoadQuery<RetriggerWorkflowQueryType>(
+    retriggerWorkflowQuery,
+    {
+      visit: instrumentSession,
+      workflowname: workflowName,
+    },
+  );
+  const templateName = data.workflow.templateRef;
+  return (
+    <>
+      {templateName ? (
+        <NavLink
+          title="Rerun workflow"
+          to={`/templates/${data.workflow.templateRef}/${visitToText(
+            instrumentSession,
+          )}-${workflowName}`}
+        >
+          <RefreshIcon />
+        </NavLink>
+      ) : (
+        <Tooltip title="No template found">
+          <RefreshIcon sx={{ color: "lightgrey" }} />
+        </Tooltip>
+      )}
+    </>
+  );
+};
+
+export default RetriggerWorkflow;

--- a/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
@@ -21,13 +21,13 @@ const singleWorkflowViewQuery = graphql`
 `;
 interface SingleWorkflowViewProps {
   visit: Visit;
-  workflowname: string;
+  workflowName: string;
   taskname?: string;
 }
 
 const SingleWorkflowView: React.FC<SingleWorkflowViewProps> = ({
   visit,
-  workflowname,
+  workflowName,
   taskname: initialTaskname,
 }) => {
   const [artifactList, setArtifactList] = useState<Artifact[]>([]);
@@ -37,7 +37,7 @@ const SingleWorkflowView: React.FC<SingleWorkflowViewProps> = ({
     singleWorkflowViewQuery,
     {
       visit,
-      workflowname,
+      workflowname: workflowName,
     },
   );
   const workflowData = useFragment<workflowFragment$key>(
@@ -54,7 +54,7 @@ const SingleWorkflowView: React.FC<SingleWorkflowViewProps> = ({
         status: task.status as TaskStatus,
         depends: [...task.depends],
         artifacts: [...task.artifacts],
-        workflow: workflowname,
+        workflow: workflowName,
         instrumentSession: visit,
       }));
     }
@@ -64,7 +64,7 @@ const SingleWorkflowView: React.FC<SingleWorkflowViewProps> = ({
       const artifacts: Artifact[] = filteredTask?.artifacts ?? [];
       setArtifactList(artifacts);
     }
-  }, [data, taskname, workflowname, visit, workflowData.status]);
+  }, [data, taskname, workflowName, visit, workflowData.status]);
 
   useEffect(() => {
     setTaskname(initialTaskname);
@@ -77,7 +77,6 @@ const SingleWorkflowView: React.FC<SingleWorkflowViewProps> = ({
         expanded={true}
         highlightedTaskName={taskname}
       />
-
       {taskname && (
         <Box sx={{ width: "100%" }}>
           <TaskInfo artifactList={artifactList} />

--- a/frontend/relay-workflows-lib/lib/components/SubmissionForm.tsx
+++ b/frontend/relay-workflows-lib/lib/components/SubmissionForm.tsx
@@ -1,11 +1,16 @@
 import { useFragment } from "react-relay";
-import { SubmissionForm as SubmissionFormBase, Visit } from "workflows-lib";
+import {
+  JSONObject,
+  SubmissionForm as SubmissionFormBase,
+  Visit,
+} from "workflows-lib";
 import { JsonSchema, UISchemaElement } from "@jsonforms/core";
 import { workflowTemplateFragment$key } from "../graphql/__generated__/workflowTemplateFragment.graphql";
 import { workflowTemplateFragment } from "../graphql/workflowTemplateFragment";
 
 const SubmissionForm = (props: {
   template: workflowTemplateFragment$key;
+  prepopulatedParameters?: JSONObject;
   visit?: Visit;
   onSubmit: (visit: Visit, parameters: object) => void;
 }) => {
@@ -18,6 +23,7 @@ const SubmissionForm = (props: {
       parametersSchema={data.arguments as JsonSchema}
       parametersUISchema={data.uiSchema as UISchemaElement}
       visit={props.visit}
+      prepopulatedParameters={props.prepopulatedParameters}
       onSubmit={props.onSubmit}
     />
   );

--- a/frontend/relay-workflows-lib/lib/components/TemplateView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/TemplateView.tsx
@@ -3,6 +3,7 @@ import { useLazyLoadQuery, useMutation } from "react-relay/hooks";
 import { graphql } from "relay-runtime";
 import { Box } from "@mui/material";
 import {
+  JSONObject,
   SubmissionGraphQLErrorMessage,
   SubmissionNetworkErrorMessage,
   SubmissionSuccessMessage,
@@ -40,8 +41,12 @@ const templateViewMutation = graphql`
 
 export default function TemplateView({
   templateName,
+  visit,
+  prepopulatedParameters,
 }: {
   templateName: string;
+  visit?: Visit;
+  prepopulatedParameters?: JSONObject;
 }) {
   const data = useLazyLoadQuery<TemplateViewQueryType>(templateViewQuery, {
     templateName,
@@ -104,6 +109,8 @@ export default function TemplateView({
         <Box>
           <SubmissionForm
             template={data.workflowTemplate}
+            prepopulatedParameters={prepopulatedParameters}
+            visit={visit}
             onSubmit={submitWorkflow}
           />
           <SubmittedMessagesList submissionResults={submissionResults} />

--- a/frontend/relay-workflows-lib/lib/components/TemplateViewRetrigger.tsx
+++ b/frontend/relay-workflows-lib/lib/components/TemplateViewRetrigger.tsx
@@ -1,0 +1,44 @@
+import { useLazyLoadQuery } from "react-relay/hooks";
+import { graphql } from "relay-runtime";
+import { JSONObject, Visit } from "workflows-lib";
+import { TemplateViewRetriggerQuery as TemplateViewRetriggerQueryType } from "./__generated__/TemplateViewRetriggerQuery.graphql";
+import TemplateView from "./TemplateView";
+
+const templateViewRetriggerQuery = graphql`
+  query TemplateViewRetriggerQuery(
+    $visit: VisitInput!
+    $workflowname: String!
+  ) {
+    workflow(visit: $visit, name: $workflowname) {
+      parameters
+    }
+  }
+`;
+
+export default function TemplateViewWithRetrigger({
+  templateName,
+  workflowName,
+  visit,
+}: {
+  templateName: string;
+  workflowName: string;
+  visit: Visit;
+}) {
+  const retriggerData = useLazyLoadQuery<TemplateViewRetriggerQueryType>(
+    templateViewRetriggerQuery,
+    {
+      visit,
+      workflowname: workflowName,
+    },
+  );
+  const prepopulatedParameters = retriggerData.workflow
+    .parameters as JSONObject;
+
+  return (
+    <TemplateView
+      templateName={templateName}
+      visit={visit}
+      prepopulatedParameters={prepopulatedParameters}
+    />
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -9,6 +9,7 @@ import { workflowFragment$key } from "../graphql/__generated__/workflowFragment.
 import { Visit } from "@diamondlightsource/sci-react-ui";
 import { useNavigate } from "react-router-dom";
 import { workflowFragment } from "../graphql/workflowFragment";
+import RetriggerWorkflow from "./RetriggerWorkflow";
 
 interface WorkflowRelayProps {
   workflow: workflowFragment$key;
@@ -59,10 +60,12 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
       <WorkflowAccordion
         workflow={{
           name: data.name,
+          instrumentSession: data.visit as Visit,
           status: statusText as WorkflowStatus,
         }}
         workflowLink={workflowLink}
         expanded={expanded}
+        retriggerComponent={RetriggerWorkflow}
       >
         <ResizableBox
           width={Infinity}

--- a/frontend/relay-workflows-lib/lib/main.ts
+++ b/frontend/relay-workflows-lib/lib/main.ts
@@ -1,2 +1,3 @@
 export { default as Workflow } from "./components/WorkflowRelay";
 export { default as Submission } from "./components/SubmissionForm";
+export {default as RetriggerWorkflow} from "./components/RetriggerWorkflow";

--- a/frontend/relay-workflows-lib/lib/utils.ts
+++ b/frontend/relay-workflows-lib/lib/utils.ts
@@ -8,3 +8,4 @@ export const isWorkflowWithTasks = (status: WorkflowStatusType) => {
       status.__typename === "WorkflowSucceededStatus"
     );
   };
+

--- a/frontend/workflows-lib/lib/components/template/SubmissionForm.tsx
+++ b/frontend/workflows-lib/lib/components/template/SubmissionForm.tsx
@@ -7,7 +7,7 @@ import { JsonForms } from "@jsonforms/react";
 import React, { useState } from "react";
 import { Divider, Snackbar, Stack, Typography, useTheme } from "@mui/material";
 import { ErrorObject } from "ajv";
-import { Visit } from "../../types";
+import { JSONObject, Visit } from "../../types";
 import { VisitInput } from "@diamondlightsource/sci-react-ui";
 
 interface TemplateSubmissionFormProps {
@@ -16,6 +16,7 @@ interface TemplateSubmissionFormProps {
   description?: string;
   parametersSchema: JsonSchema;
   parametersUISchema?: UISchemaElement;
+  prepopulatedParameters?: JSONObject;
   visit?: Visit;
   onSubmit: (visit: Visit, parameters: object) => void;
 }
@@ -26,12 +27,14 @@ const TemplateSubmissionForm: React.FC<TemplateSubmissionFormProps> = ({
   description,
   parametersSchema,
   parametersUISchema,
+  prepopulatedParameters,
   visit,
   onSubmit,
 }) => {
   const theme = useTheme();
-  const validator = createAjv({ useDefaults: true });
-  const [parameters, setParameters] = useState({});
+  const validator = createAjv({ useDefaults: true, coerceTypes: true });
+
+  const [parameters, setParameters] = useState(prepopulatedParameters ?? {});
   const [errors, setErrors] = useState<ErrorObject[]>([]);
 
   const [submitted, setSubmitted] = useState(false);
@@ -47,7 +50,7 @@ const TemplateSubmissionForm: React.FC<TemplateSubmissionFormProps> = ({
     setSubmitted(false);
   };
   const formWidth =
-    (parametersUISchema?.options?.formWidth as string | undefined) ?? "50%";
+    (parametersUISchema?.options?.formWidth as string | undefined) ?? "100%";
 
   return (
     <Stack
@@ -73,7 +76,7 @@ const TemplateSubmissionForm: React.FC<TemplateSubmissionFormProps> = ({
         cells={materialCells}
         ajv={validator}
         onChange={({ data, errors }) => {
-          setParameters(data as object);
+          setParameters(data as JSONObject);
           setErrors(errors ? errors : []);
         }}
         data-testid="paramters-form"

--- a/frontend/workflows-lib/lib/components/workflow/WorkflowAccordion.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/WorkflowAccordion.tsx
@@ -11,13 +11,17 @@ import MuiAccordionDetails from "@mui/material/AccordionDetails";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { getWorkflowStatusIcon } from "../common/StatusIcons";
-import { Workflow } from "../../types";
+import { Visit, Workflow } from "../../types";
 
 interface WorkflowProps {
   workflow: Workflow;
   children: React.ReactNode;
   workflowLink?: boolean;
   expanded?: boolean;
+  retriggerComponent?: React.ComponentType<{
+    instrumentSession: Visit;
+    workflowName: string;
+  }>;
 }
 
 const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
@@ -31,6 +35,7 @@ const WorkflowAccordion: React.FC<WorkflowProps> = ({
   children,
   workflowLink = false,
   expanded = false,
+  retriggerComponent,
 }) => {
   const resolvedPath = useResolvedPath(workflow.name);
   return (
@@ -43,6 +48,11 @@ const WorkflowAccordion: React.FC<WorkflowProps> = ({
               <OpenInNewIcon />
             </Link>
           )}
+          {retriggerComponent &&
+            React.createElement(retriggerComponent, {
+              instrumentSession: workflow.instrumentSession,
+              workflowName: workflow.name,
+            })}
           <Typography>{workflow.name}</Typography>
         </Box>
       </AccordionSummary>

--- a/frontend/workflows-lib/lib/main.ts
+++ b/frontend/workflows-lib/lib/main.ts
@@ -1,4 +1,4 @@
-export { default as WorkflowAccordion } from "./components/workflow/WorkflowAccordian";
+export { default as WorkflowAccordion } from "./components/workflow/WorkflowAccordion";
 export { default as TasksFlow } from "./components/workflow/TasksFlow";
 export { default as TasksTable } from "./components/workflow/TasksTable";
 export { default as SubmissionForm } from "./components/template/SubmissionForm";

--- a/frontend/workflows-lib/lib/types.ts
+++ b/frontend/workflows-lib/lib/types.ts
@@ -39,6 +39,7 @@ export type WorkflowStatus =
 
 export interface Workflow {
   name: string;
+  instrumentSession: Visit;
   status: WorkflowStatus;
 }
 
@@ -73,3 +74,7 @@ export interface SubmissionGraphQLErrorMessage {
   type: "graphQLError";
   errors: PayloadError[];
 };
+
+
+export type JSONValue = string | number | boolean | null | JSONObject | JSONValue[];
+export interface JSONObject { [key: string]: JSONValue }

--- a/frontend/workflows-lib/lib/utils/commonUtils.ts
+++ b/frontend/workflows-lib/lib/utils/commonUtils.ts
@@ -1,6 +1,7 @@
 import { Visit } from "../types";
 
 export const visitRegex = /^([a-z]{2})([1-9]\d*)-([1-9]\d*)/;
+export const visitWithTemplateRegex = new RegExp(`${visitRegex.source}-(.+)$`);
 
 export const visitToText = (visit?: Visit): string => {
   return visit
@@ -26,4 +27,14 @@ export function visitTextToVisit(visitid?: string): Visit | null {
     }
   }
   return null;
+}
+
+export function parseVisitAndTemplate(input: string): [Visit, string] | null {
+  const match = visitWithTemplateRegex.exec(input);
+  if (!match) return null;
+
+  const visit = regexToVisit(match);
+  const templateName = match[4];
+
+  return [visit, templateName];
 }

--- a/frontend/workflows-lib/stories/WorkflowAccordion.stories.tsx
+++ b/frontend/workflows-lib/stories/WorkflowAccordion.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fakeWorkflowA } from "./common";
-import WorkflowAccordion from "../lib/components/workflow/WorkflowAccordian";
+import WorkflowAccordion from "../lib/components/workflow/WorkflowAccordion";
 import TasksFlow from "../lib/components/workflow/TasksFlow";
 import { fakeTasksA } from "./common";
 

--- a/frontend/workflows-lib/tests/components/WorkflowAccordion.test.tsx
+++ b/frontend/workflows-lib/tests/components/WorkflowAccordion.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 import { MemoryRouter } from "react-router-dom";
 import { WorkflowAccordion } from "../../lib/main";
 import { TaskStatus, WorkflowStatus } from "../../lib/types";
+import { Visit } from "@diamondlightsource/sci-react-ui";
 
 describe("WorkflowAccordion Component", () => {
   beforeAll(() => {
@@ -14,6 +15,11 @@ describe("WorkflowAccordion Component", () => {
   const mockWorkflow = {
     name: "Test Workflow",
     status: "Running" as WorkflowStatus,
+    instrumentSession: {
+      proposalCode: "ab",
+      proposalNumber: 7295,
+      number: 5,
+    } as Visit,
     tasks: [
       { id: "Task-1", name: "Task 1", status: "Succeeded" as TaskStatus },
     ],


### PR DESCRIPTION
Adds functionality to rerun workflow from same template and input parameters. Links from workflow page to `template page/visit-workflowName`, prepopulating with input params. I've had to add a couple of layers to prevent conditionally calling hooks etc.