### PR TITLE
Add pagination

### DIFF
--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@diamondlightsource/sci-react-ui": "^0.0.3",
     "keycloak-js": "^26.2.0",
+    "react-intersection-observer": "^9.16.0",
     "react-relay": "18.2.0",
     "react-router-dom": "^7.5.1",
     "relay-workflows-lib": "*",

--- a/frontend/dashboard/src/routes/TemplatesListPage.tsx
+++ b/frontend/dashboard/src/routes/TemplatesListPage.tsx
@@ -13,7 +13,7 @@ const TemplatesListPage: React.FC = () => {
       <Container maxWidth="md">
         <WorkflowsErrorBoundary>
           <Suspense>
-            <Box mt={2}>
+            <Box mt={2} mb={2}>
               <TemplatesList />
             </Box>
           </Suspense>

--- a/frontend/relay-workflows-lib/lib/components/TemplatesList.tsx
+++ b/frontend/relay-workflows-lib/lib/components/TemplatesList.tsx
@@ -1,8 +1,10 @@
-import { useLazyLoadQuery } from "react-relay/hooks";
-import { TemplatesListQuery } from "./__generated__/TemplatesListQuery.graphql";
-import { TemplateCard } from "workflows-lib";
+import { ChangeEvent } from "react";
 import { graphql } from "relay-runtime";
-import { Box } from "@mui/material";
+import { useLazyLoadQuery } from "react-relay/hooks";
+import { Box, Pagination } from "@mui/material";
+import { TemplateCard } from "workflows-lib";
+import { TemplatesListQuery } from "./__generated__/TemplatesListQuery.graphql";
+import { useClientSidePagination } from "../utils";
 
 const templatesListQuery = graphql`
   query TemplatesListQuery {
@@ -19,12 +21,41 @@ const templatesListQuery = graphql`
 
 export default function TemplatesList() {
   const data = useLazyLoadQuery<TemplatesListQuery>(templatesListQuery, {});
+  const templates = data.workflowTemplates.nodes;
+
+  const {
+    pageNumber,
+    setPageNumber,
+    totalPages,
+    paginatedItems: paginatedPosts,
+  } = useClientSidePagination(templates, 10);
+
+  const handlePageChange = (_event: ChangeEvent<unknown>, page: number) => {
+    setPageNumber(page);
+  };
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center" width="100%">
-      {data.workflowTemplates.nodes.map((node, index) => (
+      {paginatedPosts.map((node, index) => (
         <TemplateCard key={index} template={node} />
       ))}
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          justifyContent: "center",
+          alignItems: "center",
+          gap: 2,
+          mt: 2,
+        }}
+      >
+        <Pagination
+          count={totalPages}
+          page={pageNumber}
+          onChange={handlePageChange}
+          showFirstButton
+        />
+      </Box>
     </Box>
   );
 }

--- a/frontend/relay-workflows-lib/lib/components/TemplatesList.tsx
+++ b/frontend/relay-workflows-lib/lib/components/TemplatesList.tsx
@@ -5,14 +5,8 @@ import { graphql } from "relay-runtime";
 import { Box } from "@mui/material";
 
 const templatesListQuery = graphql`
-  query TemplatesListQuery($cursor: String, $limit: Int!) {
-    workflowTemplates(cursor: $cursor, limit: $limit) {
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
+  query TemplatesListQuery {
+    workflowTemplates {
       nodes {
         name
         description
@@ -24,10 +18,7 @@ const templatesListQuery = graphql`
 `;
 
 export default function TemplatesList() {
-  const data = useLazyLoadQuery<TemplatesListQuery>(templatesListQuery, {
-    limit: 10,
-    cursor: null,
-  });
+  const data = useLazyLoadQuery<TemplatesListQuery>(templatesListQuery, {});
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center" width="100%">

--- a/frontend/relay-workflows-lib/lib/utils.ts
+++ b/frontend/relay-workflows-lib/lib/utils.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { WorkflowStatusType } from "./types";
 
 export const isWorkflowWithTasks = (status: WorkflowStatusType) => {
@@ -9,3 +10,18 @@ export const isWorkflowWithTasks = (status: WorkflowStatusType) => {
     );
   };
 
+export  function useClientSidePagination<T>(items: readonly T[] | T[], perPage: number = 10) {
+    const [pageNumber, setPageNumber] = useState(1);
+  
+    const totalPages = Math.ceil(items.length / perPage);
+    const startIndex = (pageNumber - 1) * perPage;
+    const endIndex = startIndex + perPage;
+    const paginatedItems = items.slice(startIndex, endIndex);
+  
+    return {
+      pageNumber,
+      setPageNumber,
+      totalPages,
+      paginatedItems,
+    };
+  }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3221,9 +3221,9 @@ globals@^14.0.0:
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
 globals@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-16.0.0.tgz#3d7684652c5c4fbd086ec82f9448214da49382d8"
-  integrity sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-16.2.0.tgz#19efcd1ddde2bd5efce128e5c2e441df1abc6f7c"
+  integrity sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -4440,6 +4440,11 @@ react-icons@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.5.0.tgz#8aa25d3543ff84231685d3331164c00299cdfaf2"
   integrity sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==
+
+react-intersection-observer@^9.16.0:
+  version "9.16.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz#7376d54edc47293300961010844d53b273ee0fb9"
+  integrity sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Implements client-side pagination on templates list page.
Implements infinite scrolling on workflows list page. This could be simplified further with an update t the GraphQL schema to use Relay's usePagination.

I've add a useClientSidePagination hook. The state could be moved outside, but I've kept encapsulated here as we don't need to access it outside.
