### PR TITLE
ci: better caching for graph proxy

### DIFF
--- a/.github/workflows/_graph_proxy_code.yaml
+++ b/.github/workflows/_graph_proxy_code.yaml
@@ -18,11 +18,10 @@ jobs:
           cache: false
           components: clippy,rustfmt
 
-      - name: Cache Rust Build
-        uses: Swatinem/rust-cache@v2.7.8
+      - uses: actions/cache@v4.2.3
         with:
-          shared-key: backend/graph-proxy
-          workspaces: backend
+          path: ./backend/target
+          key: graph-proxy-lint
 
       - name: Create argo workflows openapi types file
         run: |
@@ -65,11 +64,10 @@ jobs:
           cache: false
           components: rustfmt
 
-      - name: Cache Rust Build
-        uses: Swatinem/rust-cache@v2.7.8
+      - uses: actions/cache@v4.2.3
         with:
-          shared-key: backend/graph-proxy
-          workspaces: backend
+          path: ./backend/target
+          key: graph-proxy-test
 
       - name: Run Tests
         working-directory: backend/graph-proxy


### PR DESCRIPTION
I think we should move our caching for graph proxy/sessionspaces to this rather than the swatinem action. Swatinem seems to average around 1:40 for the main compile portion of the CI, vs 20-30 seconds for this caching. Happy to investigate further. Probably beneficial to frontend as well
