### PR TITLE
fix(frontend): persist tasks flow viewport & add reset button

### DIFF
--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -85,6 +85,7 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
           }}
         >
           <TasksFlow
+            workflowName={data.name}
             tasks={tasks}
             highlightedTaskName={highlightedTaskName}
             onNavigate={(path: string) => {

--- a/frontend/workflows-lib/lib/utils/tasksFlowUtils.ts
+++ b/frontend/workflows-lib/lib/utils/tasksFlowUtils.ts
@@ -1,10 +1,11 @@
+import { useCallback } from "react";
 import dagre from "@dagrejs/dagre";
-import { Node, Edge } from "@xyflow/react";
+import { Node, Edge, Viewport } from "@xyflow/react";
 import { Task, TaskNode } from "../types";
 
 export function applyDagreLayout(
   nodes: Node[],
-  edges: Edge[]
+  edges: Edge[],
 ): { nodes: Node[]; edges: Edge[] } {
   const graph = new dagre.graphlib.Graph();
 
@@ -55,11 +56,16 @@ export function buildTaskTree(tasks: Task[]): TaskNode[] {
   return roots;
 }
 
-export function isRootDag(task: TaskNode){
-  return task.stepType === "DAG" && (!task.depends || task.depends.length === 0);
+export function isRootDag(task: TaskNode) {
+  return (
+    task.stepType === "DAG" && (!task.depends || task.depends.length === 0)
+  );
 }
 
-export function generateNodesAndEdges(taskNodes: TaskNode[], highlightedTaskName?: string): {
+export function generateNodesAndEdges(
+  taskNodes: TaskNode[],
+  highlightedTaskName?: string,
+): {
   nodes: Node[];
   edges: Edge[];
 } {
@@ -69,7 +75,10 @@ export function generateNodesAndEdges(taskNodes: TaskNode[], highlightedTaskName
   const traverse = (tasks: TaskNode[], parents: string[] = []) => {
     const sortedTasks = [...tasks].sort((a, b) => a.name.localeCompare(b.name));
     sortedTasks.forEach((task) => {
-      if (!nodes.some((existingNode) => existingNode.id === task.id) && !isRootDag(task)) {
+      if (
+        !nodes.some((existingNode) => existingNode.id === task.id) &&
+        !isRootDag(task)
+      ) {
         nodes.push({
           id: task.id,
           type: "custom",
@@ -105,4 +114,27 @@ export function generateNodesAndEdges(taskNodes: TaskNode[], highlightedTaskName
 
   traverse(taskNodes);
   return { nodes, edges };
+}
+
+export function usePersistentViewport(workflowName: string) {
+  const viewport_key = `${workflowName}Viewport`;
+  const saveViewport = useCallback(
+    (viewport: Viewport | null | undefined) => {
+      if (viewport) {
+        sessionStorage.setItem(viewport_key, JSON.stringify(viewport));
+      }
+    },
+    [viewport_key],
+  );
+
+  const loadViewport = useCallback((): Viewport | null => {
+    const stored = sessionStorage.getItem(viewport_key);
+    return stored ? (JSON.parse(stored) as Viewport) : null;
+  }, [viewport_key]);
+
+  const clearViewport = useCallback(() => {
+    sessionStorage.removeItem(viewport_key);
+  }, [viewport_key]);
+
+  return { saveViewport, loadViewport, clearViewport };
 }

--- a/frontend/workflows-lib/stories/WorkflowAccordion.stories.tsx
+++ b/frontend/workflows-lib/stories/WorkflowAccordion.stories.tsx
@@ -16,7 +16,12 @@ export const Accordion: Story = {
   args: {
     workflow: fakeWorkflowA,
     children: (
-      <TasksFlow tasks={fakeTasksA} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName={fakeWorkflowA.name}
+        tasks={fakeTasksA}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />
     ),
   },
 };

--- a/frontend/workflows-lib/tests/components/TasksDynamic.test.tsx
+++ b/frontend/workflows-lib/tests/components/TasksDynamic.test.tsx
@@ -52,7 +52,12 @@ describe("TasksFlow", () => {
     console.log("Mock Tasks:", mockTasks);
 
     render(
-      <TasksFlow tasks={mockTasks} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />,
     );
     expect(screen.getByTestId("reactflow-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("taskstable-mock")).not.toBeInTheDocument();
@@ -76,7 +81,12 @@ describe("TasksFlow", () => {
     console.log("Mock Tasks:", mockTasks);
 
     render(
-      <TasksFlow tasks={mockTasks} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />,
     );
     expect(screen.getByTestId("taskstable-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("reactflow-mock")).not.toBeInTheDocument();
@@ -86,13 +96,18 @@ describe("TasksFlow", () => {
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 
     const { unmount } = render(
-      <TasksFlow tasks={mockTasks} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />,
     );
     unmount();
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "resize",
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 });

--- a/frontend/workflows-lib/tests/components/TasksFlow.test.tsx
+++ b/frontend/workflows-lib/tests/components/TasksFlow.test.tsx
@@ -1,10 +1,11 @@
-import { render } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import TasksFlow from "../../lib/components/workflow/TasksFlow";
 import {
   applyDagreLayout,
   buildTaskTree,
   generateNodesAndEdges,
+  usePersistentViewport,
 } from "../../lib/utils/tasksFlowUtils";
 import { ReactFlow } from "@xyflow/react";
 import { mockTasks } from "./data";
@@ -62,13 +63,23 @@ describe("TasksFlow Component", () => {
 
   it("should render without crashing", () => {
     const { getByText } = render(
-      <TasksFlow tasks={mockTasks} onNavigate={() => {}} />,
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
     );
     expect(getByText("ReactFlow Mock")).toBeInTheDocument();
   });
 
   it("should build the task tree", () => {
-    render(<TasksFlow tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
 
     expect(buildTaskTree).toHaveBeenCalledWith(mockTasks);
   });
@@ -76,6 +87,7 @@ describe("TasksFlow Component", () => {
   it("should generate nodes and edges based on the task tree", () => {
     render(
       <TasksFlow
+        workflowName="mockWorkflowA"
         tasks={mockTasks}
         highlightedTaskName="node-1"
         onNavigate={() => {}}
@@ -86,13 +98,25 @@ describe("TasksFlow Component", () => {
   });
 
   it("should apply the dagre layout", () => {
-    render(<TasksFlow tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
 
     expect(applyDagreLayout).toHaveBeenCalledWith(mockNodes, mockEdges);
   });
 
   it("should initialize ReactFlow with the correct nodes and edges", () => {
-    render(<TasksFlow tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
 
     expect(ReactFlow).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -113,10 +137,61 @@ describe("TasksFlow Component", () => {
         zoomOnDoubleClick: false,
         panOnDrag: true,
         preventScrolling: false,
-        fitView: true,
+        fitView: false,
         style: { width: "100%", overflow: "auto", height: "100%" },
       }),
       {},
     );
+  });
+});
+
+describe("usePersistentViewport hook tests", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  const mockViewport = { x: 20, y: 30, zoom: 2.5 };
+
+  it("should save viewport to sessionStorage", () => {
+    const { result } = renderHook(() => usePersistentViewport("testWorkflowA"));
+
+    act(() => {
+      result.current.saveViewport(mockViewport);
+    });
+
+    const stored = sessionStorage.getItem("testWorkflowAViewport");
+    expect(stored).toBe(JSON.stringify(mockViewport));
+  });
+
+  it("loads viewport from sessionStorage", () => {
+    sessionStorage.setItem(
+      "testWorkflowBViewport",
+      JSON.stringify(mockViewport),
+    );
+
+    const { result } = renderHook(() => usePersistentViewport("testWorkflowB"));
+
+    let loadedViewport;
+    act(() => {
+      loadedViewport = result.current.loadViewport();
+    });
+
+    expect(loadedViewport).toEqual(mockViewport);
+  });
+
+  it("clears viewport from sessionStorage", () => {
+    sessionStorage.setItem(
+      "testWorkflowCViewport",
+      JSON.stringify(mockViewport),
+    );
+
+    const { result } = renderHook(() => usePersistentViewport("testWorkflowC"));
+
+    act(() => {
+      result.current.clearViewport();
+    });
+
+    expect(sessionStorage.getItem("testWorkflowCViewport")).toBeNull();
   });
 });

--- a/frontend/workflows-lib/tests/components/TasksTable.test.tsx
+++ b/frontend/workflows-lib/tests/components/TasksTable.test.tsx
@@ -15,7 +15,7 @@ describe("TaskTable Component", () => {
           .mockReturnValueOnce(<span>Pending Icon</span>)
           .mockReturnValueOnce(<span>Completed Icon</span>)
           .mockReturnValueOnce(<span>In-Progress Icon</span>),
-      })
+      }),
     );
   });
 
@@ -25,7 +25,11 @@ describe("TaskTable Component", () => {
 
   it("should render without crashing", () => {
     const { getByText } = render(
-      <TasksTable tasks={mockTasks} onNavigate={() => {}} />
+      <TasksTable
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
     );
     expect(getByText("task-1")).toBeInTheDocument();
     expect(getByText("task-2")).toBeInTheDocument();
@@ -33,7 +37,13 @@ describe("TaskTable Component", () => {
   });
 
   it("should call getStatusIcon for each task", () => {
-    render(<TasksTable tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksTable
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
     expect(getTaskStatusIcon).toHaveBeenCalledWith("Pending");
     expect(getTaskStatusIcon).toHaveBeenCalledWith("Succeeded");
     expect(getTaskStatusIcon).toHaveBeenCalledWith("Running");


### PR DESCRIPTION
This fixes an issue with the tasks flow where the viewport resets when a task is clicked (highlighted). This now persists the viewport when the page is reloaded and updated. There is a button for resetting the viewport.