### PR TITLE
feat(frontend): poll workflows pages & refactor to separate pagination

### DIFF
--- a/frontend/dashboard/src/routes/WorkflowsListPage.tsx
+++ b/frontend/dashboard/src/routes/WorkflowsListPage.tsx
@@ -14,7 +14,7 @@ import {
   WorkflowsNavbar,
 } from "workflows-lib";
 import { WorkflowListFilterDisplay } from "workflows-lib/lib/components/workflow/WorkflowListFilterDrawer";
-import { useVisitInput } from "./utils";
+import { useVisitInput, ScrollRestorer } from "./utils";
 
 const WorkflowsListPage: React.FC = () => {
   const { visitid } = useParams<{ visitid: string }>();
@@ -53,6 +53,7 @@ const WorkflowsListPage: React.FC = () => {
             {visit ? (
               <WorkflowsErrorBoundary key={JSON.stringify(workflowQueryFilter)}>
                 <Suspense>
+                  <ScrollRestorer />
                   <Workflows visit={visit} filter={workflowQueryFilter} />
                 </Suspense>
               </WorkflowsErrorBoundary>

--- a/frontend/dashboard/src/routes/utils.ts
+++ b/frontend/dashboard/src/routes/utils.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Visit, visitToText } from "@diamondlightsource/sci-react-ui";
 import { visitTextToVisit } from "workflows-lib/lib/utils/commonUtils";
@@ -6,7 +6,9 @@ import { visitTextToVisit } from "workflows-lib/lib/utils/commonUtils";
 export const useVisitInput = (initialVisitId?: string) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const [visit, setVisit] = useState<Visit | null>(visitTextToVisit(initialVisitId));
+  const [visit, setVisit] = useState<Visit | null>(
+    visitTextToVisit(initialVisitId),
+  );
 
   const handleVisitSubmit = (visit: Visit | null) => {
     if (visit) {
@@ -24,3 +26,19 @@ export const useVisitInput = (initialVisitId?: string) => {
 
   return { visit, handleVisitSubmit };
 };
+
+export function ScrollRestorer() {
+  const scrollRef = useRef<number>(0);
+
+  useEffect(() => {
+    return () => {
+      scrollRef.current = window.scrollY;
+    };
+  }, []);
+
+  useEffect(() => {
+    window.scrollTo(0, scrollRef.current);
+  }, []);
+
+  return null;
+}

--- a/frontend/relay-workflows-lib/lib/components/SingleWorkflowContent.tsx
+++ b/frontend/relay-workflows-lib/lib/components/SingleWorkflowContent.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { PreloadedQuery, useFragment, usePreloadedQuery } from "react-relay";
+import { TaskInfo } from "workflows-lib/lib/components/workflow/TaskInfo";
+import { Artifact } from "workflows-lib/lib/types";
+import { singleWorkflowViewQuery } from "./SingleWorkflowView";
+import WorkflowRelay from "./WorkflowRelay";
+import { isWorkflowWithTasks } from "../utils";
+import {
+  SingleWorkflowViewQuery,
+  SingleWorkflowViewQuery as SingleWorkflowViewQueryType,
+} from "./__generated__/SingleWorkflowViewQuery.graphql";
+import { workflowFragment$key } from "../graphql/__generated__/workflowFragment.graphql";
+import { workflowFragment } from "../graphql/workflowFragment";
+
+interface SingleWorkflowContentProps {
+  queryReference: PreloadedQuery<SingleWorkflowViewQuery>;
+  taskname?: string;
+}
+
+export default function SingleWorkflowContent({
+  queryReference,
+  taskname,
+}: SingleWorkflowContentProps) {
+  const data = usePreloadedQuery<SingleWorkflowViewQueryType>(
+    singleWorkflowViewQuery,
+    queryReference,
+  );
+  const workflow = data.workflow;
+
+  const unwrappedWorkflow = useFragment<workflowFragment$key>(
+    workflowFragment,
+    workflow,
+  );
+
+  const [artifactList, setArtifactList] = useState<Artifact[]>([]);
+
+  useEffect(() => {
+    if (
+      taskname &&
+      unwrappedWorkflow.status &&
+      isWorkflowWithTasks(unwrappedWorkflow.status)
+    ) {
+      const task = unwrappedWorkflow.status.tasks.find(
+        (t) => t.name === taskname,
+      );
+      setArtifactList([...(task?.artifacts ?? [])]);
+    }
+  }, [workflow, taskname, unwrappedWorkflow.status]);
+
+  return (
+    <>
+      <WorkflowRelay
+        workflow={workflow}
+        highlightedTaskName={taskname}
+        expanded={true}
+      />
+      {taskname && (
+        <div style={{ width: "100%", marginTop: "1rem" }}>
+          <TaskInfo artifactList={artifactList} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -85,6 +85,7 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
           }}
         >
           <TasksFlow
+            workflowName={data.name}
             tasks={tasks}
             highlightedTaskName={highlightedTaskName}
             onNavigate={(path: string) => {

--- a/frontend/relay-workflows-lib/lib/components/Workflows.tsx
+++ b/frontend/relay-workflows-lib/lib/components/Workflows.tsx
@@ -1,21 +1,18 @@
-import WorkflowRelay from "relay-workflows-lib/lib/components/WorkflowRelay";
-import { WorkflowsQuery as WorkflowsQueryType } from "./__generated__/WorkflowsQuery.graphql";
-import { workflowFragment$key } from "../graphql/__generated__/workflowFragment.graphql";
-import { useLazyLoadQuery } from "react-relay/hooks";
+import { useCallback, useEffect } from "react";
+import { useQueryLoader } from "react-relay/hooks";
+import { graphql } from "react-relay";
 import { Visit, WorkflowQueryFilter } from "workflows-lib";
-import { useState, useCallback, useEffect, startTransition } from "react";
-import Pagination from "@mui/material/Pagination";
-import {
-  Box,
-  FormControl,
-  Select,
-  MenuItem,
-  SelectChangeEvent,
-} from "@mui/material";
-import { graphql } from "relay-runtime";
+import { WorkflowsQuery } from "./__generated__/WorkflowsQuery.graphql";
+import WorkflowsContent from "./WorkflowsContent";
+import { useServerSidePagination } from "./useServerSidePagination";
 
-const workflowsQuery = graphql`
-  query WorkflowsQuery($visit: VisitInput!, $cursor: String, $limit: Int!, $filter: WorkflowFilter) {
+export const workflowsQuery = graphql`
+  query WorkflowsQuery(
+    $visit: VisitInput!
+    $cursor: String
+    $limit: Int!
+    $filter: WorkflowFilter
+  ) {
     workflows(visit: $visit, cursor: $cursor, limit: $limit, filter: $filter) {
       nodes {
         ...workflowFragment
@@ -30,143 +27,58 @@ const workflowsQuery = graphql`
   }
 `;
 
-export default function Workflows({ visit, filter }: { visit: Visit, filter?: WorkflowQueryFilter }) {
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [workflows, setWorkflows] = useState<workflowFragment$key[]>([]);
-  const [cursorHistory, setCursorHistory] = useState<{
-    [page: number]: string | null;
-  }>({ 1: null });
-  const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [selectedLimit, setSelectedLimit] = useState(10);
-
-
-  const data = useLazyLoadQuery<WorkflowsQueryType>(workflowsQuery, {
-    visit,
-    limit: selectedLimit,
+export default function Workflows({
+  visit,
+  filter,
+}: {
+  visit: Visit;
+  filter?: WorkflowQueryFilter;
+}) {
+  const {
     cursor,
-    filter
-  });
+    currentPage,
+    totalPages,
+    selectedLimit,
+    goToPage,
+    changeLimit,
+    updatePageInfo,
+  } = useServerSidePagination();
 
-  const updateWorkflows = (
-    nodes: WorkflowsQueryType["response"]["workflows"]["nodes"],
-  ) => {
-    setWorkflows([...nodes]);
-  };
+  const [queryReference, loadQuery] =
+    useQueryLoader<WorkflowsQuery>(workflowsQuery);
 
-  const updateTotalPages = useCallback(
-    (pageInfo: WorkflowsQueryType["response"]["workflows"]["pageInfo"]) => {
-      const hasNextPage = pageInfo.hasNextPage;
-      const currentPageCount = Object.keys(cursorHistory).length;
-
-      if (hasNextPage && !cursorHistory[currentPage + 1]) {
-        setTotalPages(currentPageCount + 1);
-      } else {
-        setTotalPages(currentPageCount);
-      }
-    },
-    [cursorHistory, currentPage],
-  );
+  const load = useCallback(() => {
+    loadQuery(
+      { visit, limit: selectedLimit, cursor, filter },
+      { fetchPolicy: "store-and-network" },
+    );
+  }, [visit, selectedLimit, cursor, filter, loadQuery]);
 
   useEffect(() => {
-    updateWorkflows(data.workflows.nodes);
-    updateTotalPages(data.workflows.pageInfo);
-  }, [data, cursorHistory, updateTotalPages]);
+    load();
+    const interval = setInterval(load, 5000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [load]);
 
-  const handlePageChange = (
-    _event: React.ChangeEvent<unknown>,
-    page: number,
-  ) => {
-    const targetCursor = cursorHistory[page];
-    if (
-      !targetCursor &&
-      page === currentPage + 1 &&
-      data.workflows.pageInfo.hasNextPage
-    ) {
-      loadMore();
-    } else {
-      startTransition(() => {
-        setCursor(targetCursor);
-        setCurrentPage(page);
-      });
-    }
-  };
-
-  const loadMore = () => {
-    if (data.workflows.pageInfo.hasNextPage) {
-      startTransition(() => {
-        const newCursor = data.workflows.pageInfo.endCursor ?? null;
-        if (!Object.values(cursorHistory).includes(newCursor)) {
-          setCursorHistory((prevCursorHistory) => ({
-            ...prevCursorHistory,
-            [currentPage + 1]: newCursor,
-          }));
-        }
-        setCursor(newCursor);
-        setCurrentPage(currentPage + 1);
-      });
-    }
-  };
-
-  const workflowList = workflows.map((node, index) => (
-    <WorkflowRelay key={index} workflow={node} workflowLink={true} />
-  ));
-
-  const limitChanged = (event: SelectChangeEvent) => {
-    setSelectedLimit(Number(event.target.value));
-    setCursorHistory({ 1: null });
-    setCurrentPage(1);
-    setCursor(null);
-  };
+  if (!queryReference) return <div>Loading workflows</div>;
 
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        alignItems: "center",
+    <WorkflowsContent
+      queryReference={queryReference}
+      currentPage={currentPage}
+      totalPages={totalPages}
+      selectedLimit={selectedLimit}
+      onPageChange={(
+        page: number,
+        endCursor: string | null | undefined,
+        hasNextPage: boolean | undefined,
+      ) => {
+        goToPage(page, endCursor, hasNextPage);
       }}
-    >
-      {workflowList}
-
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: {
-            xs: "column",
-            sm: "row",
-          },
-          justifyContent: "center",
-          alignItems: "center",
-          gap: 2,
-          mt: 2,
-        }}
-      >
-        <Pagination
-          count={totalPages}
-          page={currentPage}
-          onChange={handlePageChange}
-          showFirstButton
-          siblingCount={1}
-          boundaryCount={0}
-        />
-
-        <FormControl sx={{ width: 80 }}>
-          <Select
-            size="small"
-            labelId="setLimitSelector"
-            value={selectedLimit.toString()}
-            aria-label="Results Per Page"
-            onChange={limitChanged}
-          >
-            <MenuItem value={5}>5</MenuItem>
-            <MenuItem value={10}>10</MenuItem>
-            <MenuItem value={20}>20</MenuItem>
-            <MenuItem value={30}>30</MenuItem>
-          </Select>
-        </FormControl>
-      </Box>
-    </div>
+      onLimitChange={changeLimit}
+      updatePageInfo={updatePageInfo}
+    />
   );
 }

--- a/frontend/relay-workflows-lib/lib/components/WorkflowsContent.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowsContent.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { PreloadedQuery, usePreloadedQuery } from "react-relay";
+import { PaginationControls } from "workflows-lib";
+import { workflowsQuery } from "./Workflows";
+import WorkflowRelay from "./WorkflowRelay";
+import {
+  WorkflowsQuery,
+  WorkflowsQuery as WorkflowsQueryType,
+} from "./__generated__/WorkflowsQuery.graphql";
+
+interface WorkflowsContentProps {
+  queryReference: PreloadedQuery<WorkflowsQuery>;
+  currentPage: number;
+  totalPages: number;
+  selectedLimit: number;
+  onPageChange: (
+    page: number,
+    endCursor?: string | null,
+    hasNextPage?: boolean,
+  ) => void;
+  onLimitChange: (limit: number) => void;
+  updatePageInfo: (hasNextPage: boolean, endCursor: string | null) => void;
+}
+
+export default function WorkflowsContent({
+  queryReference,
+  currentPage,
+  totalPages,
+  selectedLimit,
+  onPageChange,
+  onLimitChange,
+  updatePageInfo,
+}: WorkflowsContentProps) {
+  const data = usePreloadedQuery<WorkflowsQueryType>(
+    workflowsQuery,
+    queryReference,
+  );
+  const workflows = data.workflows.nodes;
+  const pageInfo = data.workflows.pageInfo;
+
+  useEffect(() => {
+    updatePageInfo(pageInfo.hasNextPage, pageInfo.endCursor ?? null);
+  }, [pageInfo, updatePageInfo]);
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+    >
+      <div style={{ overflowY: "auto", maxHeight: "80vh", width: "100%" }}>
+        {workflows.map((node, index) => (
+          <WorkflowRelay key={index} workflow={node} workflowLink={true} />
+        ))}
+      </div>
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={(page: number) => {
+          onPageChange(page, pageInfo.endCursor, pageInfo.hasNextPage);
+        }}
+        selectedLimit={selectedLimit}
+        onLimitChange={onLimitChange}
+      />
+    </div>
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/useServerSidePagination.ts
+++ b/frontend/relay-workflows-lib/lib/components/useServerSidePagination.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from "react";
+
+export function useServerSidePagination(initialLimit = 10) {
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [cursorHistory, setCursorHistory] = useState<{
+    [page: number]: string | null;
+  }>({ 1: null });
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [selectedLimit, setSelectedLimit] = useState(initialLimit);
+
+  const updatePageInfo = useCallback(
+    (hasNextPage: boolean, endCursor: string | null) => {
+      const currentPageCount = Object.keys(cursorHistory).length;
+      if (hasNextPage && !cursorHistory[currentPage + 1]) {
+        setTotalPages(currentPageCount + 1);
+      } else {
+        setTotalPages(currentPageCount);
+      }
+
+      if (
+        hasNextPage &&
+        endCursor &&
+        !Object.values(cursorHistory).includes(endCursor)
+      ) {
+        setCursorHistory((prev) => ({
+          ...prev,
+          [currentPage + 1]: endCursor,
+        }));
+      }
+    },
+    [cursorHistory, currentPage],
+  );
+
+  const goToPage = useCallback(
+    (page: number, endCursor?: string | null, hasNextPage?: boolean) => {
+      const targetCursor = cursorHistory[page];
+      if (
+        !targetCursor &&
+        page === currentPage + 1 &&
+        hasNextPage &&
+        endCursor
+      ) {
+        setCursor(endCursor);
+        setCurrentPage(page);
+      } else {
+        setCursor(targetCursor ?? null);
+        setCurrentPage(page);
+      }
+    },
+    [cursorHistory, currentPage],
+  );
+
+  const changeLimit = useCallback((limit: number) => {
+    setSelectedLimit(limit);
+    setCursorHistory({ 1: null });
+    setCurrentPage(1);
+    setCursor(null);
+  }, []);
+
+  return {
+    cursor,
+    setCursor,
+    cursorHistory,
+    setCursorHistory,
+    currentPage,
+    setCurrentPage,
+    totalPages,
+    setTotalPages,
+    selectedLimit,
+    setSelectedLimit,
+    updatePageInfo,
+    goToPage,
+    changeLimit,
+  };
+}

--- a/frontend/relay-workflows-lib/lib/utils.ts
+++ b/frontend/relay-workflows-lib/lib/utils.ts
@@ -1,27 +1,61 @@
 import { useState } from "react";
+import { Task } from "workflows-lib";
 import { WorkflowStatusType } from "./types";
+import { workflowFragment$data } from "./graphql/__generated__/workflowFragment.graphql";
 
 export const isWorkflowWithTasks = (status: WorkflowStatusType) => {
-    return (
-      status.__typename === "WorkflowErroredStatus" ||
-      status.__typename === "WorkflowFailedStatus" ||
-      status.__typename === "WorkflowRunningStatus" ||
-      status.__typename === "WorkflowSucceededStatus"
-    );
+  return (
+    status.__typename === "WorkflowErroredStatus" ||
+    status.__typename === "WorkflowFailedStatus" ||
+    status.__typename === "WorkflowRunningStatus" ||
+    status.__typename === "WorkflowSucceededStatus"
+  );
+};
+
+export function useClientSidePagination<T>(
+  items: readonly T[] | T[],
+  perPage: number = 10,
+) {
+  const [pageNumber, setPageNumber] = useState(1);
+
+  const totalPages = Math.ceil(items.length / perPage);
+  const startIndex = (pageNumber - 1) * perPage;
+  const endIndex = startIndex + perPage;
+  const paginatedItems = items.slice(startIndex, endIndex);
+
+  return {
+    pageNumber,
+    setPageNumber,
+    totalPages,
+    paginatedItems,
   };
+}
 
-export  function useClientSidePagination<T>(items: readonly T[] | T[], perPage: number = 10) {
-    const [pageNumber, setPageNumber] = useState(1);
-
-    const totalPages = Math.ceil(items.length / perPage);
-    const startIndex = (pageNumber - 1) * perPage;
-    const endIndex = startIndex + perPage;
-    const paginatedItems = items.slice(startIndex, endIndex);
-
-    return {
-      pageNumber,
-      setPageNumber,
-      totalPages,
-      paginatedItems,
-    };
+export function workflowsAreEqual(
+  a: workflowFragment$data | workflowFragment$data[],
+  b: workflowFragment$data | workflowFragment$data[],
+): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((wfA, i) => workflowsAreEqual(wfA, b[i]));
   }
+
+  if (!Array.isArray(a) && !Array.isArray(b)) {
+    if (a.status?.__typename !== b.status?.__typename) return false;
+
+    const tasksA: Task[] = (a.status as { tasks?: Task[] }).tasks ?? [];
+    const tasksB: Task[] = (b.status as { tasks?: Task[] }).tasks ?? [];
+
+    if (tasksA.length !== tasksB.length) return false;
+
+    return tasksA.every((taskA, j) => {
+      const taskB = tasksB[j];
+      return (
+        taskA.status === taskB.status &&
+        taskA.artifacts.length === taskB.artifacts.length
+      );
+    });
+  }
+
+  return false;
+}

--- a/frontend/workflows-lib/lib/components/common/PaginationControls.tsx
+++ b/frontend/workflows-lib/lib/components/common/PaginationControls.tsx
@@ -1,0 +1,55 @@
+import { Box, FormControl, MenuItem, Pagination, Select } from "@mui/material";
+
+interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  selectedLimit: number;
+  onLimitChange: (limit: number) => void;
+}
+
+export default function PaginationControls({
+  currentPage,
+  totalPages,
+  onPageChange,
+  selectedLimit,
+  onLimitChange,
+}: PaginationControlsProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", sm: "row" },
+        gap: 2,
+        mt: 2,
+      }}
+    >
+      <Pagination
+        count={totalPages}
+        page={currentPage}
+        onChange={(_, page) => {
+          onPageChange(page);
+        }}
+        showFirstButton
+        siblingCount={1}
+        boundaryCount={0}
+      />
+      <FormControl sx={{ width: 80 }}>
+        <Select
+          size="small"
+          value={selectedLimit.toString()}
+          onChange={(e) => {
+            onLimitChange(Number(e.target.value));
+          }}
+          aria-label="Results Per Page"
+        >
+          {[5, 10, 20, 30].map((val) => (
+            <MenuItem key={val} value={val}>
+              {val}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+}

--- a/frontend/workflows-lib/lib/main.ts
+++ b/frontend/workflows-lib/lib/main.ts
@@ -7,4 +7,5 @@ export { default as SubmittedMessagesList } from "./components/workflow/Submitte
 export { default as WorkflowsErrorBoundary } from "./components/workflow/WorkflowsErrorBoundary";
 export { default as WorkflowListFilterDrawer } from "./components/workflow/WorkflowListFilterDrawer";
 export { default as WorkflowsNavbar } from "./components/workflow/WorkflowsNavbar";
+export { default as PaginationControls } from "./components/common/PaginationControls";
 export * from "./types";

--- a/frontend/workflows-lib/stories/WorkflowAccordion.stories.tsx
+++ b/frontend/workflows-lib/stories/WorkflowAccordion.stories.tsx
@@ -16,7 +16,12 @@ export const Accordion: Story = {
   args: {
     workflow: fakeWorkflowA,
     children: (
-      <TasksFlow tasks={fakeTasksA} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName={fakeWorkflowA.name}
+        tasks={fakeTasksA}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />
     ),
   },
 };

--- a/frontend/workflows-lib/tests/components/TasksDynamic.test.tsx
+++ b/frontend/workflows-lib/tests/components/TasksDynamic.test.tsx
@@ -52,7 +52,12 @@ describe("TasksFlow", () => {
     console.log("Mock Tasks:", mockTasks);
 
     render(
-      <TasksFlow tasks={mockTasks} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />,
     );
     expect(screen.getByTestId("reactflow-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("taskstable-mock")).not.toBeInTheDocument();
@@ -76,7 +81,12 @@ describe("TasksFlow", () => {
     console.log("Mock Tasks:", mockTasks);
 
     render(
-      <TasksFlow tasks={mockTasks} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />,
     );
     expect(screen.getByTestId("taskstable-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("reactflow-mock")).not.toBeInTheDocument();
@@ -86,13 +96,18 @@ describe("TasksFlow", () => {
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 
     const { unmount } = render(
-      <TasksFlow tasks={mockTasks} isDynamic={true} onNavigate={() => {}} />
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        isDynamic={true}
+        onNavigate={() => {}}
+      />,
     );
     unmount();
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "resize",
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 });

--- a/frontend/workflows-lib/tests/components/TasksFlow.test.tsx
+++ b/frontend/workflows-lib/tests/components/TasksFlow.test.tsx
@@ -1,10 +1,11 @@
-import { render } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import TasksFlow from "../../lib/components/workflow/TasksFlow";
 import {
   applyDagreLayout,
   buildTaskTree,
   generateNodesAndEdges,
+  usePersistentViewport,
 } from "../../lib/utils/tasksFlowUtils";
 import { ReactFlow } from "@xyflow/react";
 import { mockTasks } from "./data";
@@ -62,13 +63,23 @@ describe("TasksFlow Component", () => {
 
   it("should render without crashing", () => {
     const { getByText } = render(
-      <TasksFlow tasks={mockTasks} onNavigate={() => {}} />,
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
     );
     expect(getByText("ReactFlow Mock")).toBeInTheDocument();
   });
 
   it("should build the task tree", () => {
-    render(<TasksFlow tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
 
     expect(buildTaskTree).toHaveBeenCalledWith(mockTasks);
   });
@@ -76,6 +87,7 @@ describe("TasksFlow Component", () => {
   it("should generate nodes and edges based on the task tree", () => {
     render(
       <TasksFlow
+        workflowName="mockWorkflowA"
         tasks={mockTasks}
         highlightedTaskName="node-1"
         onNavigate={() => {}}
@@ -86,13 +98,25 @@ describe("TasksFlow Component", () => {
   });
 
   it("should apply the dagre layout", () => {
-    render(<TasksFlow tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
 
     expect(applyDagreLayout).toHaveBeenCalledWith(mockNodes, mockEdges);
   });
 
   it("should initialize ReactFlow with the correct nodes and edges", () => {
-    render(<TasksFlow tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksFlow
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
 
     expect(ReactFlow).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -113,10 +137,61 @@ describe("TasksFlow Component", () => {
         zoomOnDoubleClick: false,
         panOnDrag: true,
         preventScrolling: false,
-        fitView: true,
+        fitView: false,
         style: { width: "100%", overflow: "auto", height: "100%" },
       }),
       {},
     );
+  });
+});
+
+describe("usePersistentViewport hook tests", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  const mockViewport = { x: 20, y: 30, zoom: 2.5 };
+
+  it("should save viewport to sessionStorage", () => {
+    const { result } = renderHook(() => usePersistentViewport("testWorkflowA"));
+
+    act(() => {
+      result.current.saveViewport(mockViewport);
+    });
+
+    const stored = sessionStorage.getItem("testWorkflowAViewport");
+    expect(stored).toBe(JSON.stringify(mockViewport));
+  });
+
+  it("loads viewport from sessionStorage", () => {
+    sessionStorage.setItem(
+      "testWorkflowBViewport",
+      JSON.stringify(mockViewport),
+    );
+
+    const { result } = renderHook(() => usePersistentViewport("testWorkflowB"));
+
+    let loadedViewport;
+    act(() => {
+      loadedViewport = result.current.loadViewport();
+    });
+
+    expect(loadedViewport).toEqual(mockViewport);
+  });
+
+  it("clears viewport from sessionStorage", () => {
+    sessionStorage.setItem(
+      "testWorkflowCViewport",
+      JSON.stringify(mockViewport),
+    );
+
+    const { result } = renderHook(() => usePersistentViewport("testWorkflowC"));
+
+    act(() => {
+      result.current.clearViewport();
+    });
+
+    expect(sessionStorage.getItem("testWorkflowCViewport")).toBeNull();
   });
 });

--- a/frontend/workflows-lib/tests/components/TasksTable.test.tsx
+++ b/frontend/workflows-lib/tests/components/TasksTable.test.tsx
@@ -15,7 +15,7 @@ describe("TaskTable Component", () => {
           .mockReturnValueOnce(<span>Pending Icon</span>)
           .mockReturnValueOnce(<span>Completed Icon</span>)
           .mockReturnValueOnce(<span>In-Progress Icon</span>),
-      })
+      }),
     );
   });
 
@@ -25,7 +25,11 @@ describe("TaskTable Component", () => {
 
   it("should render without crashing", () => {
     const { getByText } = render(
-      <TasksTable tasks={mockTasks} onNavigate={() => {}} />
+      <TasksTable
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
     );
     expect(getByText("task-1")).toBeInTheDocument();
     expect(getByText("task-2")).toBeInTheDocument();
@@ -33,7 +37,13 @@ describe("TaskTable Component", () => {
   });
 
   it("should call getStatusIcon for each task", () => {
-    render(<TasksTable tasks={mockTasks} onNavigate={() => {}} />);
+    render(
+      <TasksTable
+        workflowName="mockWorkflowA"
+        tasks={mockTasks}
+        onNavigate={() => {}}
+      />,
+    );
     expect(getTaskStatusIcon).toHaveBeenCalledWith("Pending");
     expect(getTaskStatusIcon).toHaveBeenCalledWith("Succeeded");
     expect(getTaskStatusIcon).toHaveBeenCalledWith("Running");


### PR DESCRIPTION
Adds polling to workflows list and single workflows pages.
I've split up `SingleWorkflowView` and `Workflows` and refactored pagination to make the components more manageable.