### PR TITLE
Fix clippy lints in graph-proxy, telemetry and cli

### DIFF
--- a/backend/graph-proxy/src/graphql/workflow_templates.rs
+++ b/backend/graph-proxy/src/graphql/workflow_templates.rs
@@ -270,7 +270,7 @@ impl WorkflowTemplatesFilter {
         let mut label_selectors = Vec::new();
 
         if let Some(group) = &self.science_group {
-            let this_label = format!("workflows.diamond.ac.uk/science-group={}", group);
+            let this_label = format!("workflows.diamond.ac.uk/science-group={group}");
             label_selectors.push(this_label);
         }
 

--- a/backend/graph-proxy/src/graphql/workflows.rs
+++ b/backend/graph-proxy/src/graphql/workflows.rs
@@ -543,10 +543,8 @@ impl WorkflowFilter {
         }
 
         if let Some(creator) = &self.creator {
-            let creator_label = format!(
-                "workflows.argoproj.io/creator-preferred-username={}",
-                creator
-            );
+            let creator_label =
+                format!("workflows.argoproj.io/creator-preferred-username={creator}");
             label_selectors.push(creator_label);
         }
 
@@ -721,7 +719,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -771,7 +769,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -835,7 +833,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -899,7 +897,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -963,7 +961,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1025,7 +1023,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1076,7 +1074,7 @@ mod tests {
         multiple_workflows_response_file_path.push("get-workflows.json");
 
         let workflows_endpoint = server
-            .mock("GET", &format!("/api/v1/workflows/{}", visit)[..])
+            .mock("GET", &format!("/api/v1/workflows/{visit}")[..])
             .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
                 "listOptions.limit".to_string(),
                 limit.to_string(),
@@ -1148,7 +1146,7 @@ mod tests {
         workflow_two_response_file_path.push("get-workflow-n6jsg.json");
 
         let workflows_endpoint = server
-            .mock("GET", &format!("/api/v1/workflows/{}", visit)[..])
+            .mock("GET", &format!("/api/v1/workflows/{visit}")[..])
             .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
                 "listOptions.limit".to_string(),
                 limit.to_string(),
@@ -1243,7 +1241,7 @@ mod tests {
         multiple_workflows_response_file_path.push("get-workflows.json");
 
         let workflows_endpoint = server
-            .mock("GET", &format!("/api/v1/workflows/{}", visit)[..])
+            .mock("GET", &format!("/api/v1/workflows/{visit}")[..])
             .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
                 "listOptions.limit".to_string(),
                 expected_default_limit.to_string(),
@@ -1291,7 +1289,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1308,7 +1306,7 @@ mod tests {
             s3_region: Some("us-west-2".to_string()),
         };
         let s3_client = Client::from(s3_client_args.clone());
-        let artifact_key = format!("{}/{}/main.log", workflow_name, workflow_name);
+        let artifact_key = format!("{workflow_name}/{workflow_name}/main.log");
         let argo_server_url = Url::parse(&server.url()).unwrap();
         let schema = root_schema_builder()
             .data(ArgoServerUrl(argo_server_url))
@@ -1387,7 +1385,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1453,7 +1451,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1501,7 +1499,7 @@ mod tests {
         workflows_response_file_path.push("get-workflows.json");
 
         let workflows_endpoint = server
-            .mock("GET", &format!("/api/v1/workflows/{}", visit)[..])
+            .mock("GET", &format!("/api/v1/workflows/{visit}")[..])
             .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
                 "listOptions.labelSelector".to_string(),
                 "workflows.argoproj.io/phase in (Error),workflows.argoproj.io/creator-preferred-username=enu43627".to_string(),
@@ -1537,7 +1535,7 @@ mod tests {
         workflows_endpoint.assert_async().await;
 
         let workflows_endpoint2 = server
-            .mock("GET", &format!("/api/v1/workflows/{}", visit)[..])
+            .mock("GET", &format!("/api/v1/workflows/{visit}")[..])
             .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
                 "listOptions.labelSelector".to_string(),
                 "workflows.argoproj.io/phase in (Failed, Error)".to_string(),
@@ -1583,7 +1581,7 @@ mod tests {
         let workflow_endpoint = server
             .mock(
                 "GET",
-                &format!("/api/v1/workflows/{}/{}", visit, workflow_name)[..],
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
             )
             .with_status(200)
             .with_header("content-type", "application/json")

--- a/backend/graph-proxy/src/main.rs
+++ b/backend/graph-proxy/src/main.rs
@@ -111,7 +111,7 @@ async fn main() {
                 file.write_all(schema_string.as_bytes()).unwrap();
                 info!("Schema written to {:#?}", path);
             } else {
-                println!("{}", schema_string);
+                println!("{schema_string}");
             }
         }
     }

--- a/backend/telemetry/src/lib.rs
+++ b/backend/telemetry/src/lib.rs
@@ -148,8 +148,8 @@ mod tests {
             .await;
         let base_url = server.url();
         let config = TelemetryConfig {
-            metrics_endpoint: Some(Url::parse(&format!("{}/v1/metrics", base_url)).unwrap()),
-            tracing_endpoint: Some(Url::parse(&format!("{}/v1/traces", base_url)).unwrap()),
+            metrics_endpoint: Some(Url::parse(&format!("{base_url}/v1/metrics")).unwrap()),
+            tracing_endpoint: Some(Url::parse(&format!("{base_url}/v1/traces")).unwrap()),
             telemetry_level: Level::INFO,
         };
         {

--- a/workflows-cli/src/command_runner.rs
+++ b/workflows-cli/src/command_runner.rs
@@ -93,7 +93,7 @@ impl MockCommand {
     /// Lookup command in the mapping table
     fn get_response(&self) -> (String, i32) {
         let full_command = format!("{} {}", self.cmd, self.args.join(" "));
-        println!("MOCK COMMAND: {}", full_command);
+        println!("MOCK COMMAND: {full_command}");
         let entry = self
             .mappings
             .iter()

--- a/workflows-cli/src/linter/base_linting.rs
+++ b/workflows-cli/src/linter/base_linting.rs
@@ -45,8 +45,8 @@ fn get_yaml(target: &Path) -> Result<String, String> {
 
 fn get_template_name(path: &Path) -> Result<String, String> {
     let yaml = get_yaml(path)?;
-    let docs = YamlLoader::load_from_str(&yaml)
-        .map_err(|e| format!("Manifest is not valid YAML: {}", e))?;
+    let docs =
+        YamlLoader::load_from_str(&yaml).map_err(|e| format!("Manifest is not valid YAML: {e}"))?;
 
     let doc = docs.first().ok_or("YAML document is empty")?;
 
@@ -68,11 +68,11 @@ fn lint_template(target: &Path) -> Result<Vec<String>, String> {
         .arg("--output")
         .arg("simple")
         .output()
-        .map_err(|e| format!("Failed to run Argo CLI: {}", e))?;
+        .map_err(|e| format!("Failed to run Argo CLI: {e}"))?;
 
     let stdout = String::from_utf8_lossy(&command.stdout);
     let stderr = String::from_utf8_lossy(&command.stderr);
-    let combined = format!("{}\n{}", stdout, stderr);
+    let combined = format!("{stdout}\n{stderr}");
 
     let errs = combined
         .lines()

--- a/workflows-cli/src/linter/helm.rs
+++ b/workflows-cli/src/linter/helm.rs
@@ -129,7 +129,7 @@ pub fn write_to_clean_folder(path: &Path, contents: Vec<String>) -> std::io::Res
     }
 
     for (i, content) in contents.iter().enumerate() {
-        let file_path = path.join(format!("workflow_{}.yaml", i));
+        let file_path = path.join(format!("workflow_{i}.yaml"));
         let mut file = File::create(file_path)?;
         file.write_all(content.as_bytes())?;
     }

--- a/workflows-cli/src/linter/mod.rs
+++ b/workflows-cli/src/linter/mod.rs
@@ -44,7 +44,7 @@ pub fn lint(args: LintArgs) {
 
     match results {
         Ok(results) => print_and_exit(results),
-        Err(e) => println!("Something went wrong while linting:\n{}", e),
+        Err(e) => println!("Something went wrong while linting:\n{e}"),
     }
 }
 
@@ -56,7 +56,7 @@ fn print_and_exit(results: Vec<LintResult>) {
             println!("No errors");
         } else {
             eprintln!("Errors found");
-            result.errors.iter().for_each(|e| println!("  - {}", e));
+            result.errors.iter().for_each(|e| println!("  - {e}"));
         }
     });
     match results.iter().any(|result| !result.errors.is_empty()) {
@@ -109,7 +109,7 @@ mod tests {
 
         let mut expected_result = vec![LintResult::new("template1".to_string(), vec![])];
 
-        println!("Response: {:?}", result);
+        println!("Response: {result:?}");
         assert!(have_same_elements(&mut result, &mut expected_result));
         assert_eq!(result, expected_result);
     }
@@ -128,7 +128,7 @@ mod tests {
             LintResult::new("template3".to_string(), vec![]),
         ];
 
-        println!("Response: {:?}", result);
+        println!("Response: {result:?}");
         assert!(have_same_elements(&mut result, &mut expected_result));
     }
 
@@ -146,8 +146,7 @@ mod tests {
         let err_msg = result.unwrap_err();
         assert!(
             err_msg.contains("Error reading directory"),
-            "Unexpected error message: {}",
-            err_msg
+            "Unexpected error message: {err_msg}"
         );
     }
 

--- a/workflows-cli/src/main.rs
+++ b/workflows-cli/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
     let args = Cli::parse();
 
     if let Err(err) = ensure_cli() {
-        eprintln!("Error: {}", err);
+        eprintln!("Error: {err}");
         std::process::exit(1)
     }
 


### PR DESCRIPTION
Fixed warnings reported by `cargo clippy --all-targets --all-features`.
No functional changes.