### PR TITLE
feat(frontend): add workflows live update switch

### DIFF
--- a/frontend/relay-workflows-lib/lib/components/Workflows.tsx
+++ b/frontend/relay-workflows-lib/lib/components/Workflows.tsx
@@ -91,6 +91,7 @@ export default function Workflows({
       onLimitChange={changeLimit}
       updatePageInfo={updatePageInfo}
       isPaginated={isPaginated}
+      setIsPaginated={setIsPaginated}
       visit={visit}
     />
   );

--- a/frontend/relay-workflows-lib/lib/utils.ts
+++ b/frontend/relay-workflows-lib/lib/utils.ts
@@ -89,45 +89,18 @@ export function workflowsAreEqual(
         return false;
       }
     }
-
     return true;
   }
-
   return false;
-}
-
-function partitionWorkflows(
-  fetchedNames: string[],
-  visibleNames: string[],
-): [string[], string[]] {
-  return fetchedNames.reduce<[string[], string[]]>(
-    ([updated, added], n) => {
-      if (visibleNames.includes(n)) {
-        updated.push(n);
-      } else {
-        added.push(n);
-      }
-      return [updated, added];
-    },
-    [[], []],
-  );
 }
 
 export function updateWorkflowsState(
   fetched: string[],
   visible: string[],
   currentNew: string[],
-  setVisible: (w: string[]) => void,
   setNew: (w: string[]) => void,
 ) {
-  const [updated, added] = partitionWorkflows(fetched, visible);
-
-  const namesChanged =
-    updated.length !== visible.length ||
-    updated.some((name, i) => name !== visible[i]);
-  if (namesChanged) {
-    setVisible(updated);
-  }
+  const added = fetched.filter((name) => !visible.includes(name));
 
   const combined = [...new Set([...currentNew, ...added])];
   const newChanged =


### PR DESCRIPTION
This switches live update on/off for workflows list. The "Update New Workflows" button only appears on page 1. Updated some of the workflow updating logic to prevent rerenders.