### PR TITLE
fix(dependabot): merge cargo ecosystems

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,6 +32,7 @@ updates:
   - package-ecosystem: cargo
     directories:
       - /backend/
+      - /workflows-cli/
     schedule:
       interval: weekly
     groups:
@@ -61,17 +62,6 @@ updates:
         patterns:
           - vite
           - vitest
-    commit-message:
-      prefix: "chore(deps)"
-  - package-ecosystem: cargo
-    directories:
-      - /workflows-cli/
-    schedule:
-      interval: weekly
-    groups:
-      patch:
-        update-types:
-          - patch
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
The previous approach wasn't right and created duplicate PR when updating the same components in backend and in workflows-cli. 
This should cut down on the noise created by dependabot by bundling them all together.