### PR TITLE
Fix node version

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,6 +20,8 @@ updates:
       - /backend/sessionspaces/.devcontainer/
       - /backend/graph-proxy/.devcontainer/
       - /workflows-cli/.devcontainer/
+      - /frontend/
+      - /frontend/.devcontainer/
     schedule:
       interval: weekly
     groups:
@@ -64,4 +66,3 @@ updates:
           - vitest
     commit-message:
       prefix: "chore(deps)"
-

--- a/frontend/.devcontainer/Dockerfile
+++ b/frontend/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:22.12-bookworm

--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "workflow-UI",
-  "image": "docker.io/library/node:22.12-bookworm",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2.4.2": {
       "username": "none",


### PR DESCRIPTION
Had an issue where the version of vite was incompatible with the version of node in the `/frontend` dev container. This should fix that and hopefully prevent it from happening in the future.