### PR TITLE
fix(dashboard): use custom nginx conf

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 
 COPY ./configure.sh .
 COPY --from=build /app/dashboard/dist /usr/share/nginx/html
-COPY ./container_utils/default.conf.template /etc/nginx/templates/default.conf.template
+COPY ./container_utils/default.conf.template /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 


### PR DESCRIPTION
The previous dashboard release didn't work. Changing to explicitly calling the nginx startup command rather than using the default container entry seemed to loose our nginx config. The actual container was fine, but without this we have no healthchecks and so kubernetes wouldn't let the pod start. There was no downtime, but the latest changes aren't live.

You'll notice the container is now not a .template file - This doesnt seem to matter, and I'm not sure why it was originally as there is no templating involved in the .conf file