### PR TITLE
Shortcuts for task selection

### DIFF
--- a/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { TaskInfo } from "workflows-lib/lib/components/workflow/TaskInfo";
-import { Artifact, Task, TaskStatus } from "workflows-lib/lib/types";
+import { Artifact, Task, TaskNode, TaskStatus } from "workflows-lib/lib/types";
 import WorkflowRelay, { workflowRelayQuery } from "./WorkflowRelay";
 import { isWorkflowWithTasks } from "../utils";
 import { Visit } from "@diamondlightsource/sci-react-ui";
 import { WorkflowRelayQuery as WorkflowRelayQueryType } from "./__generated__/WorkflowRelayQuery.graphql";
+import { Box, ToggleButton } from "@mui/material";
+import { buildTaskTree } from "workflows-lib/lib/utils/tasksFlowUtils";
 
 interface SingleWorkflowViewProps {
   visit: Visit;
@@ -22,49 +24,124 @@ export default function SingleWorkflowView({
     visit: visit,
     name: workflowName,
   });
-  const workflow = data.workflow;
 
   const [artifactList, setArtifactList] = useState<Artifact[]>([]);
+  const [outputSelected, setOutputSelected] = useState<boolean>(false);
+  const [outputTasks, setOutputTasks] = useState<string[]>([]);
+  const [selectedTasks, setSelectedTasks] = useState<string[]>([]);
+  const [fetchedTasks, setFetchedTasks] = useState<Task[]>([]);
+
+  const taskTree = useMemo(() => buildTaskTree(fetchedTasks), [fetchedTasks]);
+
+  const handleSelectOutput = () => {
+    setOutputSelected(!outputSelected);
+  };
 
   useEffect(() => {
-    let fetchedTasks: Task[] = [];
     if (data.workflow.status && isWorkflowWithTasks(data.workflow.status)) {
-      fetchedTasks = data.workflow.status.tasks.map((task) => ({
-        id: task.id,
-        name: task.name,
-        status: task.status as TaskStatus,
-        artifacts: task.artifacts.map((artifact) => ({
-          ...artifact,
-          parentTask: task.name,
-          key: `${task.name}-${artifact.name}`,
-        })),
-        workflow: workflowName,
-        instrumentSession: visit,
-        stepType: task.stepType,
-      }));
+      setFetchedTasks(
+        data.workflow.status.tasks.map((task) => ({
+          id: task.id,
+          name: task.name,
+          status: task.status as TaskStatus,
+          depends: [...task.depends],
+          artifacts: task.artifacts.map((artifact) => ({
+            ...artifact,
+            parentTask: task.name,
+            key: `${task.name}-${artifact.name}`,
+          })),
+          workflow: workflowName,
+          instrumentSession: visit,
+          stepType: task.stepType,
+        }))
+      );
     }
+  }, [data.workflow.status]);
 
-    const filteredTasks = tasknames?.length
-      ? tasknames
+  useEffect(() => {
+    const filteredTasks = selectedTasks?.length
+      ? selectedTasks
           .map((name) => fetchedTasks.find((task) => task.name === name))
           .filter((task): task is Task => !!task)
       : fetchedTasks;
     setArtifactList(filteredTasks.flatMap((task) => task.artifacts));
-  }, [workflow, tasknames, data.workflow.status]);
+  }, [selectedTasks, fetchedTasks]);
+
+  useEffect(() => {
+    let newOutputTasks: string[] = [];
+    const traverse = (tasks: TaskNode[]) => {
+      const sortedTasks = [...tasks].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      sortedTasks.forEach((taskNode) => {
+        if (
+          taskNode.children &&
+          taskNode.children.length == 0 &&
+          !newOutputTasks.includes(taskNode.name)
+        ) {
+          newOutputTasks.push(taskNode.name);
+        } else if (taskNode.children && taskNode.children.length > 0) {
+          traverse(taskNode.children);
+        }
+      });
+    };
+    traverse(taskTree);
+    setOutputTasks(newOutputTasks);
+  }, [taskTree]);
+
+  useEffect(() => {
+    if (outputSelected) {
+      setSelectedTasks(outputTasks);
+    } else {
+      setSelectedTasks(tasknames ? tasknames : []);
+    }
+  }, [outputTasks, outputSelected, tasknames]);
 
   return (
     <>
-      <WorkflowRelay
-        key={workflowName}
-        visit={visit}
-        workflowName={workflowName}
-        workflowLink
-        expanded={true}
-        highlightedTaskNames={tasknames}
-      />
-      <div style={{ width: "100%", marginTop: "1rem" }}>
-        <TaskInfo artifactList={artifactList} />
-      </div>
+      <Box
+        sx={{
+          position: "relative",
+          display: "inline-flex",
+          alignItems: "flex-start",
+          width: "100%",
+          height: "100%",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            width: "100%",
+            height: "100%",
+            gap: 2,
+          }}
+        >
+          <ToggleButton
+            value="output"
+            aria-label="output"
+            selected={outputSelected}
+            onClick={handleSelectOutput}
+            sx={{ position: "absolute", left: "-100px" }}
+          >
+            OUTPUT
+          </ToggleButton>
+          <WorkflowRelay
+            key={workflowName}
+            visit={visit}
+            workflowName={workflowName}
+            fetchedTasks={fetchedTasks}
+            workflowLink
+            expanded={true}
+            highlightedTaskNames={selectedTasks}
+          />
+        </Box>
+      </Box>
+      {tasknames && (
+        <div style={{ width: "100%", marginTop: "1rem" }}>
+          <TaskInfo artifactList={artifactList} />
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
@@ -37,9 +37,13 @@ export default function SingleWorkflowView({
     setSelectedTasks(outputTasks);
   };
 
+  const handleSelectClear = () => {
+    setSelectedTasks([]);
+  };
+
   useEffect(() => {
     setSelectedTasks(tasknames ? tasknames : []);
-  }, [tasknames]);
+  }, [tasknames, setSelectedTasks]);
 
   useEffect(() => {
     if (data.workflow.status && isWorkflowWithTasks(data.workflow.status)) {
@@ -60,20 +64,19 @@ export default function SingleWorkflowView({
         }))
       );
     }
-  }, [data.workflow.status]);
+  }, [data.workflow.status, setFetchedTasks, visit, workflowName]);
 
   useEffect(() => {
-    const filteredTasks = selectedTasks?.length
+    const filteredTasks = selectedTasks.length
       ? selectedTasks
           .map((name) => fetchedTasks.find((task) => task.name === name))
           .filter((task): task is Task => !!task)
       : fetchedTasks;
     setArtifactList(filteredTasks.flatMap((task) => task.artifacts));
-    setSelectedTasks(selectedTasks);
   }, [selectedTasks, fetchedTasks]);
 
   useEffect(() => {
-    let newOutputTasks: string[] = [];
+    const newOutputTasks: string[] = [];
     const traverse = (tasks: TaskNode[]) => {
       const sortedTasks = [...tasks].sort((a, b) =>
         a.name.localeCompare(b.name)
@@ -114,17 +117,31 @@ export default function SingleWorkflowView({
             gap: 2,
           }}
         >
-          <ToggleButton
-            value="output"
-            aria-label="output"
-            onClick={handleSelectOutput}
+          <Box
+            display="flex"
+            flexDirection="column"
+            gap={1}
             sx={{ position: "absolute", left: "-100px" }}
           >
-            OUTPUT
-          </ToggleButton>
+            <ToggleButton
+              value="output"
+              aria-label="output"
+              onClick={handleSelectOutput}
+            >
+              OUTPUT
+            </ToggleButton>
+            <ToggleButton
+              value="output"
+              aria-label="output"
+              onClick={handleSelectClear}
+            >
+              CLEAR
+            </ToggleButton>
+          </Box>
+
           <WorkflowRelay
             workflowName={data.workflow.name}
-            visit={data.workflow.visit as Visit}
+            visit={data.workflow.visit}
             workflowLink
             expanded={true}
           />

--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -152,7 +152,7 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
         }))
       );
     }
-  }, [data.workflow.status]);
+  }, [data.workflow.status, visit, workflowName]);
 
   const onNavigate = React.useCallback(
     (path: string, event?: React.MouseEvent) => {
@@ -173,7 +173,7 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
       }
       setSelectedTasks(updatedTasks);
     },
-    [selectedTasks]
+    [selectedTasks, setFetchedTasks]
   );
 
   return (

--- a/frontend/relay-workflows-lib/lib/components/workflowRelayUtils.ts
+++ b/frontend/relay-workflows-lib/lib/components/workflowRelayUtils.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 
 export function updateSearchParamsWithTasks(
@@ -36,9 +36,12 @@ export function useSelectedTasks(): [string[], (tasks: string[]) => void] {
     [searchParams]
   );
 
-  const setSelectedTasks = (tasks: string[]) => {
-    updateSearchParamsWithTasks(tasks, searchParams, setSearchParams);
-  };
+  const setSelectedTasks = useCallback(
+    (tasks: string[]) => {
+      updateSearchParamsWithTasks(tasks, searchParams, setSearchParams);
+    },
+    [searchParams, setSearchParams]
+  );
 
   return [selectedTasks, setSelectedTasks];
 }

--- a/frontend/relay-workflows-lib/lib/components/workflowRelayUtils.ts
+++ b/frontend/relay-workflows-lib/lib/components/workflowRelayUtils.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export function updateSearchParamsWithTasks(
+  updatedTasks: string[],
+  searchParams: URLSearchParams,
+  setSearchParams: (params: URLSearchParams) => void
+) {
+  const params = new URLSearchParams(searchParams);
+  if (updatedTasks.length > 0) {
+    params.set("tasks", JSON.stringify(updatedTasks));
+  } else {
+    params.delete("tasks");
+  }
+  setSearchParams(params);
+}
+
+export function getTasksFromSearchParams(searchParams: URLSearchParams) {
+  const taskParam = searchParams.get("tasks");
+  if (!taskParam) return [];
+  try {
+    const parsed = JSON.parse(taskParam) as string[];
+    return Array.isArray(parsed) && parsed.every((t) => typeof t === "string")
+      ? parsed
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function useSelectedTasks(): [string[], (tasks: string[]) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedTasks = useMemo(
+    () => getTasksFromSearchParams(searchParams),
+    [searchParams]
+  );
+
+  const setSelectedTasks = (tasks: string[]) => {
+    updateSearchParamsWithTasks(tasks, searchParams, setSearchParams);
+  };
+
+  return [selectedTasks, setSelectedTasks];
+}


### PR DESCRIPTION
Adds an `OUTPUT` and `CLEAR` button on the single workflow page as shortcuts for selecting output tasks and clearing all selected tasks.