### PR TITLE
fix(kyverno): bump CPU

### DIFF
--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -3,4 +3,4 @@ name: apps
 description: An argocd app to deploy apps inside the virtual cluster
 type: application
 
-version: 0.4.5
+version: 0.4.6

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -29,10 +29,10 @@ kyverno:
       container:
         resources:
           limits:
-            cpu: 2
+            cpu: 6
             memory: 8Gi
           requests:
-            cpu: 1
+            cpu: 5
             memory: 4Gi
     backgroundController:
       extraArgs:
@@ -42,10 +42,10 @@ kyverno:
       replicas: 2
       resources:
         limits:
-          cpu: 4
+          cpu: 6
           memory: 32Gi
         requests:
-          cpu: 2
+          cpu: 5
           memory: 16Gi
     cleanupController:
       enabled: false


### PR DESCRIPTION
Both controllers are throttling. Not sure why alert manager hasn't sent an email about this. I've bumped the CPU but we'll have to keep an eye to see if they need more. Both pods are at around 200% usage but seems to be spikes of roughly 2 hours every now and then rather than being consistently high. I'm away from today so if you approve, go ahead and merge it as well.

EDIT:
Interesting - the pods are well over their requests and almost maxed out, but the actual throttling is registering on grafana as 0%, which explains why we aren't getting any sort of notification