### PR TITLE
fix(relay-workflows-lib): fix live update bug

### DIFF
--- a/frontend/relay-workflows-lib/lib/components/WorkflowsContent.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowsContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { Box, Button, FormControlLabel, Switch, useTheme } from "@mui/material";
 import { Visit } from "@diamondlightsource/sci-react-ui";
@@ -40,9 +40,10 @@ export default function WorkflowsContent({
   const theme = useTheme();
   const data = usePreloadedQuery(workflowsQuery, queryReference);
   const pageInfo = data.workflows.pageInfo;
-  const fetchedWorkflows = data.workflows.nodes.map(
+  const fetchedWorkflows = useMemo(() => { 
+    return data.workflows.nodes.map(
     (wf: { readonly name: string }) => wf.name,
-  );
+  )}, [data.workflows.nodes]);
   const prevFetchedRef = useRef<string[]>([]);
 
   const [visibleWorkflows, setVisibleWorkflows] =


### PR DESCRIPTION
Fixes https://jira.diamond.ac.uk/browse/AP-794
There was a bug where if live update is on, clicking on a workflow link or task did not take you to the single workflow page, despite updating the URL correctly. I think this was because the navigation was being interupted by a useEffect which ran every time the link was clicked. This was fixed by memoizing `fetchedWorkflows`, which meant the useEffect was only ran if the fetchedWorkflows has actually changed.