### PR TITLE
fix(groups): change httomo source type to helm

### DIFF
--- a/charts/groups/Chart.yaml
+++ b/charts/groups/Chart.yaml
@@ -3,4 +3,4 @@ name: group-projects
 description: A collection of AppProjects and Apps for science domain groups
 type: application
 
-version: 0.3.9
+version: 0.3.10

--- a/charts/groups/values.yaml
+++ b/charts/groups/values.yaml
@@ -24,6 +24,7 @@ groups:
       - name: imaging-httomo
         repoURL: https://github.com/DiamondLightSource/imaging-workflows
         path: httomo
+        sourceType: helm
       - name: imaging-e02
         repoURL: https://github.com/DiamondLightSource/imaging-workflows
         path: e02


### PR DESCRIPTION
This PR corresponds with the following PR in the imaging-workflows repo: https://github.com/DiamondLightSource/imaging-workflows/pull/34