### PR TITLE
feat(frontend): add ScanRangeInput component and json forms renderer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,9 +26,9 @@
     "@mui/x-date-pickers": "^7.28.3",
     "@xyflow/react": "^12.8.3",
     "ajv": "^8.17.1",
+    "graphql-ws": "^6.0.6",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "graphql-ws": "^6.0.6"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/frontend/workflows-lib/lib/components/template/controls/ScanRangeInput.tsx
+++ b/frontend/workflows-lib/lib/components/template/controls/ScanRangeInput.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useState } from "react";
+import { Box, InputAdornment, TextField, Tooltip } from "@mui/material";
+import { InfoOutlined } from "@mui/icons-material";
+import { ScanRangeInputProps } from "../../../types";
+import { validateScanRange } from "../../../utils/validationUtils";
+
+const ScanRangeInput = ({ name, value, handleChange }: ScanRangeInputProps) => {
+  const [scanRange, setScanRange] = useState({
+    start: String(value.start),
+    end: String(value.end),
+  });
+
+  const [excludedRaw, setExcludedRaw] = useState(
+    (value.excluded ?? []).join(", "),
+  );
+  const [errors, setErrors] = useState({
+    start: "",
+    end: "",
+    excluded: "",
+  });
+
+  const [hasUserEditedExcluded, setHasUserEditedExcluded] = useState(false);
+
+  const validateAndUpdate = useCallback(() => {
+    const result = validateScanRange(
+      scanRange.start,
+      scanRange.end,
+      excludedRaw,
+    );
+    setErrors(result.errors);
+
+    if (result.parsed) {
+      const current = {
+        start: Number(scanRange.start),
+        end: Number(scanRange.end),
+        excluded: result.parsed.excluded,
+      };
+
+      const isEqual =
+        current.start === value.start &&
+        current.end === value.end &&
+        JSON.stringify(current.excluded) ===
+          JSON.stringify(value.excluded ?? []);
+
+      if (!isEqual) {
+        handleChange(name, result.parsed);
+      }
+    }
+  }, [scanRange, excludedRaw, handleChange, name, value]);
+
+  const handleFieldChange =
+    (field: keyof typeof scanRange) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setScanRange({ ...scanRange, [field]: event.target.value });
+    };
+
+  const handleExcludedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setExcludedRaw(event.target.value);
+    setHasUserEditedExcluded(true);
+  };
+
+  useEffect(() => {
+    setScanRange({
+      start: String(value.start),
+      end: String(value.end),
+    });
+
+    if (!hasUserEditedExcluded) {
+      setExcludedRaw((value.excluded ?? []).join(", "));
+    }
+  }, [value.start, value.end, value.excluded, hasUserEditedExcluded]);
+
+  useEffect(() => {
+    validateAndUpdate();
+  }, [scanRange, excludedRaw, validateAndUpdate]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        gap: 2,
+        alignItems: "flex-start",
+        paddingTop: "20px",
+      }}
+    >
+      <TextField
+        type="number"
+        label="Start"
+        value={scanRange.start}
+        onChange={handleFieldChange("start")}
+        error={!!errors.start}
+        helperText={errors.start || " "}
+        slotProps={{
+          htmlInput: { step: 1 },
+          formHelperText: { sx: { minHeight: "3em", whiteSpace: "pre-wrap" } },
+          inputLabel: { shrink: true },
+        }}
+        onWheel={(event) => {
+          (event.target as HTMLInputElement).blur();
+        }}
+      />
+      <TextField
+        type="number"
+        label="End"
+        value={scanRange.end}
+        onChange={handleFieldChange("end")}
+        error={!!errors.end}
+        helperText={errors.end || " "}
+        slotProps={{
+          htmlInput: { step: 1 },
+          formHelperText: { sx: { minHeight: "3em", whiteSpace: "pre-wrap" } },
+          inputLabel: { shrink: true },
+        }}
+        onWheel={(event) => {
+          (event.target as HTMLInputElement).blur();
+        }}
+      />
+      <TextField
+        label="Excluded"
+        value={excludedRaw}
+        onChange={handleExcludedChange}
+        error={!!errors.excluded}
+        helperText={errors.excluded || " "}
+        slotProps={{
+          formHelperText: { sx: { minHeight: "3em", whiteSpace: "pre-wrap" } },
+          inputLabel: { shrink: true },
+          input: {
+            endAdornment: (
+              <InputAdornment position="end">
+                <Tooltip title="Accepts integers ond ranges separated by spaces or commas i.e. 1 2, 5-9, 11.">
+                  <InfoOutlined color="action" />
+                </Tooltip>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+    </Box>
+  );
+};
+
+export default ScanRangeInput;

--- a/frontend/workflows-lib/lib/components/template/jsonforms/JsonFormsScanRangeRenderer.tsx
+++ b/frontend/workflows-lib/lib/components/template/jsonforms/JsonFormsScanRangeRenderer.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { ControlProps } from "@jsonforms/core";
+import ScanRangeInput from "../controls/ScanRangeInput";
+import { ScanRange } from "../../../types";
+import { useEffect, useState } from "react";
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const ScanRangeControl = ({ data, path, handleChange }: ControlProps) => {
+  const [localValue, setLocalValue] = useState<ScanRange>({
+    start: data?.start,
+    end: data?.end,
+    excluded: data?.excluded ?? [],
+  });
+
+  const handleBufferedChange = (_: string, value: ScanRange) => {
+    setLocalValue(value);
+    handleChange(path, value);
+  };
+
+  useEffect(() => {
+    setLocalValue({
+      start: data?.start,
+      end: data?.end,
+      excluded: data?.excluded ?? [],
+    });
+  }, [data]);
+
+  return (
+    <ScanRangeInput
+      name={path}
+      value={localValue}
+      handleChange={handleBufferedChange}
+    />
+  );
+};
+
+const JsonFormsScanRangeRenderer = withJsonFormsControlProps(ScanRangeControl);
+
+export default JsonFormsScanRangeRenderer;

--- a/frontend/workflows-lib/lib/main.ts
+++ b/frontend/workflows-lib/lib/main.ts
@@ -9,5 +9,7 @@ export { default as WorkflowListFilterDrawer } from "./components/workflow/Workf
 export { default as WorkflowsNavbar } from "./components/workflow/WorkflowsNavbar";
 export { default as PaginationControls } from "./components/common/PaginationControls";
 export { default as FileUploadButton } from "./components/template/controls/FileUploadButton";
+export { default as ScanRangeInput } from "./components/template/controls/ScanRangeInput";
 export { default as JsonFormsFileUploadRenderer } from "./components/template/jsonforms/JsonFormsFileUploadRenderer";
+export { default as JsonFormsScanRangeRenderer } from "./components/template/jsonforms/JsonFormsScanRangeRenderer";
 export * from "./types";

--- a/frontend/workflows-lib/lib/types.ts
+++ b/frontend/workflows-lib/lib/types.ts
@@ -98,6 +98,18 @@ export interface FileUploadButtonProps {
   handleChange: (path: string, value: UploadedFile) => void;
 }
 
+export interface ScanRange {
+  start: number;
+  end: number;
+  excluded?: number[];
+}
+
+export interface ScanRangeInputProps {
+  name: string;
+  value: ScanRange;
+  handleChange: (path: string, value: ScanRange) => void;
+}
+
 export type JSONValue =
   | string
   | number

--- a/frontend/workflows-lib/lib/utils/testers.ts
+++ b/frontend/workflows-lib/lib/utils/testers.ts
@@ -5,3 +5,9 @@ export const fileUploadTester = rankWith(
   (uischema) =>
     isControl(uischema) && uischema.options?.useFileUploadControl === true,
 );
+
+export const scanRangeTester = rankWith(
+  5,
+  (uischema) =>
+    isControl(uischema) && uischema.options?.useScanRangeControl === true,
+);

--- a/frontend/workflows-lib/lib/utils/validationUtils.ts
+++ b/frontend/workflows-lib/lib/utils/validationUtils.ts
@@ -1,0 +1,102 @@
+import { ScanRange } from "../types";
+
+export const isStrictPositiveInteger = (value: string): boolean =>
+  /^\d+$/.test(value) && Number(value) >= 0;
+
+export const parseExcludedScans = (input: string): number[] => {
+  const cleaned = input.replace(/[[\]]/g, "");
+
+  const parts = cleaned
+    .split(/[\s,]+/)
+    .map((part) => part.trim())
+    .filter((part) => part !== "");
+
+  const resultSet = new Set<number>();
+
+  for (const part of parts) {
+    if (/^\d+$/.test(part)) {
+      resultSet.add(Number(part));
+    } else if (/^\d+-\d+$/.test(part)) {
+      const [startStr, endStr] = part.split("-");
+      if (
+        !isStrictPositiveInteger(startStr) ||
+        !isStrictPositiveInteger(endStr)
+      ) {
+        throw new Error("Invalid range");
+      }
+      const start = Number(startStr);
+      const end = Number(endStr);
+      if (start >= end) {
+        throw new Error("Invalid range");
+      }
+      for (let i = start; i <= end; i++) {
+        resultSet.add(i);
+      }
+    } else {
+      throw new Error("Must be positive integers or ranges");
+    }
+  }
+
+  return Array.from(resultSet).sort((a, b) => a - b);
+};
+
+export interface ScanRangeValidationResult {
+  errors: {
+    start: string;
+    end: string;
+    excluded: string;
+  };
+  parsed?: ScanRange;
+}
+
+export const validateScanRange = (
+  startStr: string,
+  endStr: string,
+  excludedRaw: string,
+): ScanRangeValidationResult => {
+  const validStart = isStrictPositiveInteger(startStr);
+  const validEnd = isStrictPositiveInteger(endStr);
+
+  const newStart = parseInt(startStr, 10);
+  const newEnd = parseInt(endStr, 10);
+
+  let excludedScans: number[] = [];
+  let excludedError = "";
+
+  try {
+    excludedScans =
+      excludedRaw.trim() === "" ? [] : parseExcludedScans(excludedRaw);
+    const outOfRange = excludedScans.filter(
+      (num) => num < newStart || num > newEnd,
+    );
+    if (outOfRange.length > 0) {
+      excludedError = "Excluded values out of range";
+    }
+  } catch (err: unknown) {
+    excludedError = (err as Error).message;
+  }
+
+  const startError = validStart ? "" : "Start must be a positive integer";
+  const endError = !validEnd
+    ? "End must be a positive integer"
+    : newEnd < newStart
+      ? "End cannot be less than start"
+      : "";
+
+  const hasErrors = startError || endError || excludedError;
+
+  return {
+    errors: {
+      start: startError,
+      end: endError,
+      excluded: excludedError,
+    },
+    parsed: hasErrors
+      ? undefined
+      : {
+          start: newStart,
+          end: newEnd,
+          excluded: excludedScans,
+        },
+  };
+};

--- a/frontend/workflows-lib/stories/JsonFormsScanRangeRenderer.stories.tsx
+++ b/frontend/workflows-lib/stories/JsonFormsScanRangeRenderer.stories.tsx
@@ -1,0 +1,60 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { JsonForms } from "@jsonforms/react";
+import { JsonFormsScanRangeRenderer } from "../lib/main";
+import { scanRangeTester } from "../lib/utils/testers";
+
+const schema = {
+  type: "object",
+  properties: {
+    scanRange: {
+      type: "object",
+      properties: {
+        start: { type: "number" },
+        end: { type: "number" },
+        excluded: {
+          type: "array",
+          items: { type: "number" },
+        },
+      },
+      required: ["start", "end", "excluded"],
+    },
+  },
+};
+
+const uischema = {
+  type: "Control",
+  scope: "#/properties/scanRange",
+  options: {
+    useScanRangeControl: true,
+  },
+};
+
+const meta: Meta = {
+  title: "Controls/jsonforms/ScanRangeRenderer",
+  component: JsonFormsScanRangeRenderer,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <JsonForms
+      schema={schema}
+      uischema={uischema}
+      data={{
+        scanRange: {
+          start: 1,
+          end: 10,
+          excluded: [5],
+        },
+      }}
+      renderers={[
+        { tester: scanRangeTester, renderer: JsonFormsScanRangeRenderer },
+      ]}
+      onChange={(data) => {
+        console.log("Updated:", data);
+      }}
+    />
+  ),
+};

--- a/frontend/workflows-lib/stories/ScanRangeInput.stories.tsx
+++ b/frontend/workflows-lib/stories/ScanRangeInput.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { ScanRangeInput } from "../lib/main";
+
+const meta: Meta<typeof ScanRangeInput> = {
+  title: "Controls/ScanRangeInput",
+  component: ScanRangeInput,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: "Input for scan range with start, end and excluded scans",
+      },
+    },
+  },
+  argTypes: {
+    name: { control: "text" },
+    value: { control: "object" },
+    handleChange: { action: "changed" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: "scanRange",
+    value: { start: 1, end: 10, excluded: [5, 6] },
+    handleChange: (name: string, value: unknown) => {
+      console.log("Updated:", name, value);
+    },
+  },
+};
+
+export const EmptyExcluded: Story = {
+  args: {
+    name: "scanRange",
+    value: { start: 1, end: 10, excluded: [] },
+    handleChange: (name: string, value: unknown) => {
+      console.log("Updated:", name, value);
+    },
+  },
+};
+
+export const InvalidRange: Story = {
+  args: {
+    name: "scanRange",
+    value: { start: 10, end: 5, excluded: [] },
+    handleChange: (name: string, value: unknown) => {
+      console.log("Updated:", name, value);
+    },
+  },
+};

--- a/frontend/workflows-lib/tests/components/ScanRangeInput.test.tsx
+++ b/frontend/workflows-lib/tests/components/ScanRangeInput.test.tsx
@@ -1,0 +1,265 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import { ScanRangeInput } from "../../lib/main";
+
+describe("ScanRangeInput", () => {
+  const defaultProps = {
+    name: "scanRange",
+    value: { start: 1, end: 10, excluded: [5, 6] },
+    handleChange: vi.fn(),
+  };
+
+  it("renders all input fields", () => {
+    render(<ScanRangeInput {...defaultProps} />);
+    expect(screen.getByLabelText("Start")).toBeInTheDocument();
+    expect(screen.getByLabelText("End")).toBeInTheDocument();
+    expect(screen.getByLabelText("Excluded")).toBeInTheDocument();
+  });
+
+  it("displays initial values correctly", () => {
+    render(<ScanRangeInput {...defaultProps} />);
+    expect(screen.getByLabelText("Start")).toHaveValue(1);
+    expect(screen.getByLabelText("End")).toHaveValue(10);
+    expect(screen.getByLabelText("Excluded")).toHaveValue("5, 6");
+  });
+
+  it("calls handleChange with valid input", async () => {
+    const mockHandleChange = vi.fn();
+    render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 10, excluded: [] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+
+    const startInput = screen.getByLabelText("Start");
+    const endInput = screen.getByLabelText("End");
+    const excludedInput = screen.getByLabelText("Excluded");
+
+    fireEvent.change(screen.getByLabelText("Start"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("End"), { target: { value: "12" } });
+    fireEvent.change(screen.getByLabelText("Excluded"), {
+      target: { value: "3, 4" },
+    });
+    fireEvent.blur(startInput);
+    fireEvent.blur(endInput);
+    fireEvent.blur(excludedInput);
+
+    await waitFor(() => {
+      expect(mockHandleChange).toHaveBeenCalledWith("scanRange", {
+        start: 2,
+        end: 12,
+        excluded: [3, 4],
+      });
+    });
+  });
+
+  it("does not overwrite excludedRaw when value.excluded updates", () => {
+    const mockHandleChange = vi.fn();
+    const { rerender } = render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 10, excluded: [5, 7] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+    const excludedInput = screen.getByLabelText("Excluded");
+    fireEvent.change(excludedInput, {
+      target: { value: "5-7" },
+    });
+    rerender(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 10, excluded: [5, 6, 7] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+    expect(excludedInput).toHaveValue("5-7");
+  });
+
+  it("shows error when end is less than start", async () => {
+    render(<ScanRangeInput {...defaultProps} />);
+
+    const endInput = screen.getByLabelText("End");
+
+    fireEvent.change(screen.getByLabelText("End"), { target: { value: "0" } });
+    fireEvent.blur(endInput);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("End cannot be less than start"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show error when end is equal to start", async () => {
+    render(<ScanRangeInput {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText("End"), { target: { value: "1" } });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("End cannot be less than start"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows error for invalid excluded values", async () => {
+    render(<ScanRangeInput {...defaultProps} />);
+
+    const excludedInput = screen.getByLabelText("Excluded");
+
+    fireEvent.change(screen.getByLabelText("Excluded"), {
+      target: { value: "abc" },
+    });
+    fireEvent.blur(excludedInput);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Must be positive integers or ranges"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error for excluded values out of range", async () => {
+    render(<ScanRangeInput {...defaultProps} />);
+
+    const excludedInput = screen.getByLabelText("Excluded");
+
+    fireEvent.change(excludedInput, {
+      target: { value: "0, 11" },
+    });
+
+    fireEvent.blur(excludedInput);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Excluded values out of range"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("parses bracketed excluded values correctly", async () => {
+    const mockHandleChange = vi.fn();
+    render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 10, excluded: [] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+
+    const excludedInput = screen.getByLabelText("Excluded");
+
+    fireEvent.change(excludedInput, {
+      target: { value: "[2, 3]" },
+    });
+
+    fireEvent.blur(excludedInput);
+
+    await waitFor(() => {
+      expect(mockHandleChange).toHaveBeenCalledWith("scanRange", {
+        start: 1,
+        end: 10,
+        excluded: [2, 3],
+      });
+    });
+  });
+
+  it("parses hyphenated excluded ranges correctly", async () => {
+    const mockHandleChange = vi.fn();
+    render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 10, excluded: [] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+    const excludedInput = screen.getByLabelText("Excluded");
+
+    fireEvent.change(screen.getByLabelText("Excluded"), {
+      target: { value: "2-4, 7-8" },
+    });
+    fireEvent.blur(excludedInput);
+
+    await waitFor(() => {
+      expect(mockHandleChange).toHaveBeenCalledWith("scanRange", {
+        start: 1,
+        end: 10,
+        excluded: [2, 3, 4, 7, 8],
+      });
+    });
+  });
+
+  it("sorts values in range correctly", async () => {
+    const mockHandleChange = vi.fn();
+    render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 10, end: 100, excluded: [] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+    const excludedInput = screen.getByLabelText("Excluded");
+
+    fireEvent.change(screen.getByLabelText("Excluded"), {
+      target: { value: "20-22, 14-16, 30-33" },
+    });
+    fireEvent.blur(excludedInput);
+
+    await waitFor(() => {
+      expect(mockHandleChange).toHaveBeenCalledWith("scanRange", {
+        start: 10,
+        end: 100,
+        excluded: [14, 15, 16, 20, 21, 22, 30, 31, 32, 33],
+      });
+    });
+  });
+  it("parses mixed-format excluded values correctly", async () => {
+    const mockHandleChange = vi.fn();
+    render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 20, excluded: [] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+    const excludedInput = screen.getByLabelText("Excluded");
+    fireEvent.change(excludedInput, {
+      target: { value: "2, 3 4-6 10,12-13" },
+    });
+    fireEvent.blur(excludedInput);
+    await waitFor(() => {
+      expect(mockHandleChange).toHaveBeenCalledWith("scanRange", {
+        start: 1,
+        end: 20,
+        excluded: [2, 3, 4, 5, 6, 10, 12, 13],
+      });
+    });
+  });
+  it("parses space-separated excluded values correctly", async () => {
+    const mockHandleChange = vi.fn();
+    render(
+      <ScanRangeInput
+        name="scanRange"
+        value={{ start: 1, end: 10, excluded: [] }}
+        handleChange={mockHandleChange}
+      />,
+    );
+    const excludedInput = screen.getByLabelText("Excluded");
+    fireEvent.change(excludedInput, {
+      target: { value: "2 3 4" },
+    });
+    fireEvent.blur(excludedInput);
+    await waitFor(() => {
+      expect(mockHandleChange).toHaveBeenCalledWith("scanRange", {
+        start: 1,
+        end: 10,
+        excluded: [2, 3, 4],
+      });
+    });
+  });
+});

--- a/frontend/workflows-lib/tests/functions/validationUtils.test.ts
+++ b/frontend/workflows-lib/tests/functions/validationUtils.test.ts
@@ -1,0 +1,125 @@
+import {
+  isStrictPositiveInteger,
+  parseExcludedScans,
+  validateScanRange,
+} from "../../lib/utils/validationUtils";
+
+describe("isStrictPositiveInteger", () => {
+  it("returns true for positive integers", () => {
+    expect(isStrictPositiveInteger("1")).toBe(true);
+    expect(isStrictPositiveInteger("100")).toBe(true);
+  });
+
+  it("returns true for zero", () => {
+    expect(isStrictPositiveInteger("0")).toBe(true);
+  });
+
+  it("returns false for negative, floats, string and scientific notation", () => {
+    expect(isStrictPositiveInteger("-1")).toBe(false);
+    expect(isStrictPositiveInteger("1.5")).toBe(false);
+    expect(isStrictPositiveInteger("1e3")).toBe(false);
+    expect(isStrictPositiveInteger("abc")).toBe(false);
+  });
+});
+
+describe("parseExcludedScans", () => {
+  it("parses comma-separated integers", () => {
+    expect(parseExcludedScans("1, 2, 3")).toEqual([1, 2, 3]);
+  });
+
+  it("parses bracketed input", () => {
+    expect(parseExcludedScans("[4, 5]")).toEqual([4, 5]);
+  });
+
+  it("parses hyphenated ranges", () => {
+    expect(parseExcludedScans("6-8")).toEqual([6, 7, 8]);
+  });
+
+  it("parses mixed input", () => {
+    expect(parseExcludedScans("1, 3-5, [7, 8]")).toEqual([1, 3, 4, 5, 7, 8]);
+  });
+
+  it("trims spaces", () => {
+    expect(parseExcludedScans("1  ,    3-5, [  7,     ,  8 ]")).toEqual([
+      1, 3, 4, 5, 7, 8,
+    ]);
+  });
+  it("removes extra commas and square brackets", () => {
+    expect(parseExcludedScans("[][][[4-5]]]], ],,]7")).toEqual([4, 5, 7]);
+  });
+
+  it("orders output", () => {
+    expect(parseExcludedScans("10, 3-5, [8]")).toEqual([3, 4, 5, 8, 10]);
+  });
+
+  it("throws error for invalid range format", () => {
+    expect(() => parseExcludedScans("5-")).toThrow(
+      "Must be positive integers or ranges",
+    );
+    expect(() => parseExcludedScans("a-b")).toThrow(
+      "Must be positive integers or ranges",
+    );
+    expect(() => parseExcludedScans("10-5")).toThrow("Invalid range");
+  });
+});
+
+describe("validateScanRange", () => {
+  it("validates correct input", () => {
+    const result = validateScanRange("1", "10", "3, 4, 5");
+    expect(result.errors).toEqual({ start: "", end: "", excluded: "" });
+    expect(result.parsed).toEqual({ start: 1, end: 10, excluded: [3, 4, 5] });
+  });
+
+  it("returns error for invalid start", () => {
+    const result = validateScanRange("abc", "10", "3, 4");
+    expect(result.errors.start).toBe("Start must be a positive integer");
+    expect(result.parsed).toBeUndefined();
+  });
+
+  it("returns error for invalid end", () => {
+    const result = validateScanRange("1", "abc", "3, 4");
+    expect(result.errors.end).toBe("End must be a positive integer");
+    expect(result.parsed).toBeUndefined();
+  });
+
+  it("returns error when end < start", () => {
+    const result = validateScanRange("10", "5", "3, 4");
+    expect(result.errors.end).toBe("End cannot be less than start");
+    expect(result.parsed).toBeUndefined();
+  });
+
+  it("returns error for excluded values out of range", () => {
+    const result = validateScanRange("1", "5", "2, 6");
+    expect(result.errors.excluded).toBe("Excluded values out of range");
+    expect(result.parsed).toBeUndefined();
+  });
+
+  it("returns error for invalid excluded format", () => {
+    const result = validateScanRange("1", "10", "abc");
+    expect(result.errors.excluded).toBe("Must be positive integers or ranges");
+    expect(result.parsed).toBeUndefined();
+  });
+
+  it("returns empty excluded array for empty input", () => {
+    const result = validateScanRange("1", "10", "");
+    expect(result.errors.excluded).toBe("");
+    expect(result.parsed?.excluded).toEqual([]);
+  });
+  it("handles duplicates", () => {
+    const result = validateScanRange("1", "10", "1, 1, 9");
+    expect(result.errors).toEqual({ start: "", end: "", excluded: "" });
+    expect(result.parsed?.excluded).toEqual([1, 9]);
+  });
+
+  it("handles overlapping ranges", () => {
+    const result = validateScanRange("1", "10", "3-5, 4-6");
+    expect(result.errors).toEqual({ start: "", end: "", excluded: "" });
+    expect(result.parsed?.excluded).toEqual([3, 4, 5, 6]);
+  });
+
+  it("handles mixed excluded input", () => {
+    const result = validateScanRange("1", "10", "3, 3-5, [4, 5]");
+    expect(result.errors).toEqual({ start: "", end: "", excluded: "" });
+    expect(result.parsed?.excluded).toEqual([3, 4, 5]);
+  });
+});


### PR DESCRIPTION
Adds ScanRangeInput component which is a scan range input field with start end and optional excluded inputs as text fields. For start and end these validate positive integers (and 0) where end is not less than start. The excluded input validates a string of comma separated integers in the range of start and end. It also trims whitespace and square brackets before converting to a number array. ScanInputRange is wrapped for use as a JSON forms custom renderer with tester function. 