### PR TITLE
fix(backend): force redirect from http to https

### DIFF
--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dashboard
 description: A dashboard for Diamond workflows
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.7
 dependencies:
   - name: common

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -43,6 +43,11 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "86400"
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Adds redirect from http to https.
Adds HSTS header with short max-age (1 day) for testing.
Bumps ArgoCD chart version to 0.3.14.