### PR TITLE
feat(frontend): allow all image types

### DIFF
--- a/frontend/workflows-lib/lib/components/workflow/ArtifactFilteredList.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/ArtifactFilteredList.tsx
@@ -30,7 +30,7 @@ export const ArtifactFilteredList: React.FC<ArtifactFilteredListProps> = ({
   };
 
   const imageArtifacts = useMemo(() => {
-    return artifactList.filter((artifact) => artifact.mimeType === "image/png");
+    return artifactList.filter((artifact) => artifact.mimeType.startsWith("image"));
   }, [artifactList]);
 
   const listedArtifacts = useMemo(() => {

--- a/frontend/workflows-lib/lib/components/workflow/TaskInfo.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/TaskInfo.tsx
@@ -18,7 +18,7 @@ interface TaskInfoProps {
 export const TaskInfo: React.FC<TaskInfoProps> = ({ artifactList }) => {
   const imageArtifactsInfos: ImageInfo[] = useMemo(() => {
     return artifactList
-      .filter((artifact) => artifact.mimeType === "image/png")
+      .filter((artifact) => artifact.mimeType.startsWith("image"))
       .map((artifact, index) => ({
         src: artifact.url,
         alt: `Gallery Image ${String(index + 1)}`,

--- a/frontend/workflows-lib/tests/components/ArtifactFilteredList.test.tsx
+++ b/frontend/workflows-lib/tests/components/ArtifactFilteredList.test.tsx
@@ -9,14 +9,14 @@ describe("ArtifactFilteredList", () => {
     expect(screen.getByText("image1.png")).toBeInTheDocument();
     expect(screen.getByText("main.log")).toBeInTheDocument();
     expect(screen.getByText("textfile.txt")).toBeInTheDocument();
-    expect(screen.getByText("image2.png")).toBeInTheDocument();
+    expect(screen.getByText("image2.jpeg")).toBeInTheDocument();
   });
 
   it('filters and displays only image artifacts when "IMAGES" filter is selected', () => {
     render(<ArtifactFilteredList artifactList={mockArtifacts} />);
     fireEvent.click(screen.getByLabelText("images"));
     expect(screen.getByText("image1.png")).toBeInTheDocument();
-    expect(screen.getByText("image2.png")).toBeInTheDocument();
+    expect(screen.getByText("image2.jpeg")).toBeInTheDocument();
     expect(screen.queryByText("main.log")).not.toBeInTheDocument();
     expect(screen.queryByText("textfile.txt")).not.toBeInTheDocument();
   });
@@ -27,7 +27,7 @@ describe("ArtifactFilteredList", () => {
     expect(screen.getByText("main.log")).toBeInTheDocument();
     expect(screen.queryByText("image1.png")).not.toBeInTheDocument();
     expect(screen.queryByText("textfile.txt")).not.toBeInTheDocument();
-    expect(screen.queryByText("image2.png")).not.toBeInTheDocument();
+    expect(screen.queryByText("image2.jpeg")).not.toBeInTheDocument();
   });
 
   it('filters and displays only text artifacts when "TEXT" filter is selected', () => {
@@ -36,6 +36,6 @@ describe("ArtifactFilteredList", () => {
     expect(screen.getByText("main.log")).toBeInTheDocument();
     expect(screen.getByText("textfile.txt")).toBeInTheDocument();
     expect(screen.queryByText("image1.png")).not.toBeInTheDocument();
-    expect(screen.queryByText("image2.png")).not.toBeInTheDocument();
+    expect(screen.queryByText("image2.jpeg")).not.toBeInTheDocument();
   });
 });

--- a/frontend/workflows-lib/tests/components/TaskInfo.test.tsx
+++ b/frontend/workflows-lib/tests/components/TaskInfo.test.tsx
@@ -1,42 +1,81 @@
-import { render, screen } from '@testing-library/react';
-import { TaskInfo } from '../../lib/components/workflow/TaskInfo';
-import type { Artifact } from 'workflows-lib';
-import '@testing-library/jest-dom';
-import { mockArtifacts } from './data';
+import { render, screen } from "@testing-library/react";
+import { TaskInfo } from "../../lib/components/workflow/TaskInfo";
+import type { Artifact } from "workflows-lib";
+import "@testing-library/jest-dom";
+import { mockArtifacts } from "./data";
 
-describe('TaskInfo', () => {
-  it('renders ArtifactFilteredList and ImageGallery components', () => {
+describe("TaskInfo", () => {
+  it("renders ArtifactFilteredList and ImageGallery components", () => {
     render(<TaskInfo artifactList={mockArtifacts} />);
-    expect(screen.getByText('image1.png')).toBeInTheDocument();
-    expect(screen.getByText('main.log')).toBeInTheDocument();
-    expect(screen.getByText('textfile.txt')).toBeInTheDocument();
-    expect(screen.getByAltText('Gallery Image 1')).toBeInTheDocument();
+    expect(screen.getByText("image1.png")).toBeInTheDocument();
+    expect(screen.getByText("main.log")).toBeInTheDocument();
+    expect(screen.getByText("textfile.txt")).toBeInTheDocument();
+    expect(screen.getByAltText("Gallery Image 1")).toBeInTheDocument();
   });
 
-  it('passes artifactList to ArtifactFilteredList and ImageGallery components', () => {
+  it("passes artifactList to ArtifactFilteredList and ImageGallery components", () => {
     render(<TaskInfo artifactList={mockArtifacts} />);
-    const artifactFilteredList = screen.getByText('image1.png').closest('div');
-    const imageGallery = screen.getByAltText('Gallery Image 1').closest('div');
+    const artifactFilteredList = screen.getByText("image1.png").closest("div");
+    const imageGallery = screen.getByAltText("Gallery Image 1").closest("div");
     expect(artifactFilteredList).toBeInTheDocument();
     expect(imageGallery).toBeInTheDocument();
   });
 
-  it('does not render ImageGallery if there are no image artifacts', () => {
+  it("does not render ImageGallery if there are no image artifacts", () => {
     const noImageArtifacts: Artifact[] = [
-      { 
-        name: 'main.log',
-        mimeType: 'text/plain',
-        url: 'fakepath/to/main.log',
-        parentTask: 'task1',
+      {
+        name: "main.log",
+        mimeType: "text/plain",
+        url: "fakepath/to/main.log",
+        parentTask: "task1",
       },
       {
-        name: 'textfile.txt',
-        mimeType: 'text/plain',
-        url: 'fakepath/to/textfile.txt',
-        parentTask: 'task2',
+        name: "textfile.txt",
+        mimeType: "text/plain",
+        url: "fakepath/to/textfile.txt",
+        parentTask: "task2",
       },
     ];
     render(<TaskInfo artifactList={noImageArtifacts} />);
-    expect(screen.queryByAltText('Gallery Image 1')).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Gallery Image 1")).not.toBeInTheDocument();
+  });
+
+  it("counts png as an image type", () => {
+    const pngArtifact: Artifact[] = [
+      {
+        name: "image1.png",
+        mimeType: "image/png",
+        url: "fakepath/to/image1.png",
+        parentTask: "task1",
+      },
+    ];
+    render(<TaskInfo artifactList={pngArtifact} />);
+    expect(screen.queryByAltText("Gallery Image 1")).toBeInTheDocument();
+  });
+
+  it("counts jpeg as an image type", () => {
+    const pngArtifact: Artifact[] = [
+      {
+        name: "image1.jpeg",
+        mimeType: "image/jpeg",
+        url: "fakepath/to/image1.jpeg",
+        parentTask: "task1",
+      },
+    ];
+    render(<TaskInfo artifactList={pngArtifact} />);
+    expect(screen.queryByAltText("Gallery Image 1")).toBeInTheDocument();
+  });
+
+  it("counts tiff as an image type", () => {
+    const pngArtifact: Artifact[] = [
+      {
+        name: "image1.tiff",
+        mimeType: "image/tiff",
+        url: "fakepath/to/image1.tiff",
+        parentTask: "task1",
+      },
+    ];
+    render(<TaskInfo artifactList={pngArtifact} />);
+    expect(screen.queryByAltText("Gallery Image 1")).toBeInTheDocument();
   });
 });

--- a/frontend/workflows-lib/tests/components/data.ts
+++ b/frontend/workflows-lib/tests/components/data.ts
@@ -25,9 +25,9 @@ export const mockArtifacts: Artifact[] = [
     parentTask: "task2",
   },
   {
-    name: "image2.png",
-    mimeType: "image/png",
-    url: "fakepath/to/image2.png",
+    name: "image2.jpeg",
+    mimeType: "image/jpeg",
+    url: "fakepath/to/image2.jpeg",
     parentTask: "task3",
   },
 ];


### PR DESCRIPTION
Fixes https://jira.diamond.ac.uk/browse/AP-817
Counts any artifact with a mime type that begins with `image/` as an image.