### PR TITLE
fix(workflows): enforce ttl on all workflows

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows
 description: Data Analysis workflow orchestration
 type: application
 
-version: 0.13.16
+version: 0.13.17
 
 dependencies:
   - name: argo-workflows

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -36,6 +36,8 @@ argo-workflows:
     workflowDefaults:
       spec:
         serviceAccountName: argo-workflow
+        ttlStrategy:
+          secondsAfterCompletion: 300
   server:
     replicas: 3
     authModes: ["client"]


### PR DESCRIPTION
300 seconds is the default - this is already enforced on workflows that are directly submitted (rather than via templates). 

Adding this will clear up the workflow from the k8s api and - most importantly - release any associate PVC.

(This has been checked in staging)