### PR TITLE
Optimise dealing with workflow subscription data

### DIFF
--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -37,6 +37,7 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
 }) => {
   const [workflowData, setWorkflowData] =
     React.useState<workflowRelaySubscription$data | null>(null);
+  const workflowHashRef = React.useRef("");
 
   useSubscription<WorkflowRelaySubscriptionType>({
     subscription: workflowRelaySubscription,
@@ -46,11 +47,12 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
     },
     onNext: (response?: workflowRelaySubscription$data | null) => {
       const normalised = getNormalisedResponse(response);
-      if (
-        normalised &&
-        stringify(normalised.workflow) !== stringify(workflowData?.workflow)
-      ) {
-        setWorkflowData(normalised);
+      if (normalised) {
+        const newHash = stringify(normalised.workflow);
+        if (newHash !== workflowHashRef.current) {
+          setWorkflowData(normalised);
+          workflowHashRef.current = newHash;
+        }
       }
     },
     onError: (error) => {

--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -15,6 +15,8 @@ import { useFetchedTasks, useSelectedTasks } from "./workflowRelayUtils";
 import { workflowRelaySubscription } from "../graphql/workflowRelaySubscription.ts";
 import { workflowRelaySubscription$data } from "../graphql/__generated__/workflowRelaySubscription.graphql";
 import { workflowRelaySubscription as WorkflowRelaySubscriptionType } from "../graphql/__generated__/workflowRelaySubscription.graphql";
+import { getNormalisedResponse } from "../utils.ts";
+import stringify from "fast-json-stable-stringify";
 
 interface WorkflowRelayProps {
   visit: Visit;
@@ -43,8 +45,12 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
       name: workflowName,
     },
     onNext: (response?: workflowRelaySubscription$data | null) => {
-      if (response) {
-        setWorkflowData(response);
+      const normalised = getNormalisedResponse(response);
+      if (
+        normalised &&
+        stringify(normalised.workflow) !== stringify(workflowData?.workflow)
+      ) {
+        setWorkflowData(normalised);
       }
     },
     onError: (error) => {
@@ -58,6 +64,7 @@ const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
   const navigate = useNavigate();
   const statusText = workflowData?.workflow.status?.__typename ?? "Unknown";
   const fetchedTasks = useFetchedTasks(workflowData, visit, workflowName);
+
   const [selectedTasks, setSelectedTasks] = useSelectedTasks();
 
   const onNavigate = React.useCallback(

--- a/frontend/relay-workflows-lib/lib/utils.ts
+++ b/frontend/relay-workflows-lib/lib/utils.ts
@@ -1,6 +1,11 @@
 import { useState } from "react";
+
 import type { workflowRelayQuery$data } from "./graphql/__generated__/workflowRelayQuery.graphql";
+import { workflowRelaySubscription$data } from "./graphql/__generated__/workflowRelaySubscription.graphql";
 type WorkflowStatusType = NonNullable<
+  workflowRelayQuery$data["workflow"]["status"]
+>;
+type WorkflowStatus = NonNullable<
   workflowRelayQuery$data["workflow"]["status"]
 >;
 
@@ -30,6 +35,33 @@ export function useClientSidePagination<T>(
     totalPages,
     paginatedItems,
   };
+}
+
+function hasTasks(
+  status: WorkflowStatus | null | undefined,
+): status is Extract<WorkflowStatus, { tasks: readonly unknown[] }> {
+  return !!status && "tasks" in status && Array.isArray(status.tasks);
+}
+
+export function getNormalisedResponse(
+  response?: workflowRelaySubscription$data | null,
+): workflowRelaySubscription$data | null | undefined {
+  let normalised = response;
+  if (hasTasks(response?.workflow.status)) {
+    normalised = {
+      ...response,
+      workflow: {
+        ...response.workflow,
+        status: {
+          ...response.workflow.status,
+          tasks: [...response.workflow.status.tasks].sort((a, b) =>
+            a.name.localeCompare(b.name),
+          ),
+        },
+      },
+    };
+  }
+  return normalised;
 }
 
 export function updateWorkflowsState(

--- a/frontend/workflows-lib/lib/utils/tasksFlowUtils.ts
+++ b/frontend/workflows-lib/lib/utils/tasksFlowUtils.ts
@@ -75,8 +75,7 @@ export function generateNodesAndEdges(taskNodes: TaskNode[]): {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
   const traverse = (tasks: TaskNode[], parents: string[] = []) => {
-    const sortedTasks = [...tasks].sort((a, b) => a.name.localeCompare(b.name));
-    sortedTasks.forEach((task) => {
+    tasks.forEach((task) => {
       if (
         !nodes.some((existingNode) => existingNode.id === task.id) &&
         !isRedundantStep(task)


### PR DESCRIPTION
https://jira.diamond.ac.uk/browse/AP-883

We are receiving lots of workflow subscription data, even when workflows are the same. They looked different to the frontend because the tasks are in a random order, so these are sorted before comparing the workflow with the last one received, so we only re-render when the new workflow data is meaningfully different.