### PR TITLE
feat(frontend): add mocking

### DIFF
--- a/frontend/dashboard/.env.mock
+++ b/frontend/dashboard/.env.mock
@@ -1,0 +1,1 @@
+VITE_ENABLE_MOCKING=true

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "mock": "vite --mode mock",
     "build": "relay-compiler --validate && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -12,6 +13,7 @@
   },
   "dependencies": {
     "keycloak-js": "^26.2.0",
+    "msw": "^2.10.5",
     "react-relay": "20.1.1",
     "react-router-dom": "^7.8.2",
     "relay-workflows-lib": "*",
@@ -26,5 +28,10 @@
   "peerDependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/frontend/dashboard/public/mockServiceWorker.js
+++ b/frontend/dashboard/public/mockServiceWorker.js
@@ -1,0 +1,343 @@
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = "2.10.4";
+const INTEGRITY_CHECKSUM = "f5825c521429caf22a4dd13b66e243af";
+const IS_MOCKED_RESPONSE = Symbol("isMockedResponse");
+const activeClientIds = new Set();
+
+addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+addEventListener("message", async function (event) {
+  const clientId = Reflect.get(event.source || {}, "id");
+
+  if (!clientId || !self.clients) {
+    return;
+  }
+
+  const client = await self.clients.get(clientId);
+
+  if (!client) {
+    return;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  });
+
+  switch (event.data) {
+    case "KEEPALIVE_REQUEST": {
+      sendToClient(client, {
+        type: "KEEPALIVE_RESPONSE",
+      });
+      break;
+    }
+
+    case "INTEGRITY_CHECK_REQUEST": {
+      sendToClient(client, {
+        type: "INTEGRITY_CHECK_RESPONSE",
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      });
+      break;
+    }
+
+    case "MOCK_ACTIVATE": {
+      activeClientIds.add(clientId);
+
+      sendToClient(client, {
+        type: "MOCKING_ENABLED",
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      });
+      break;
+    }
+
+    case "MOCK_DEACTIVATE": {
+      activeClientIds.delete(clientId);
+      break;
+    }
+
+    case "CLIENT_CLOSED": {
+      activeClientIds.delete(clientId);
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId;
+      });
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister();
+      }
+
+      break;
+    }
+  }
+});
+
+addEventListener("fetch", function (event) {
+  // Bypass navigation requests.
+  if (event.request.mode === "navigate") {
+    return;
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === "only-if-cached" &&
+    event.request.mode !== "same-origin"
+  ) {
+    return;
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return;
+  }
+
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ */
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event);
+  const requestCloneForEvents = event.request.clone();
+  const response = await getResponse(event, client, requestId);
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents);
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone();
+
+    sendToClient(
+      client,
+      {
+        type: "RESPONSE",
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    );
+  }
+
+  return response;
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId);
+
+  if (activeClientIds.has(event.clientId)) {
+    return client;
+  }
+
+  if (client?.frameType === "top-level") {
+    return client;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  });
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === "visible";
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id);
+    });
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone();
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers);
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get("accept");
+    if (acceptHeader) {
+      const values = acceptHeader.split(",").map((value) => value.trim());
+      const filteredValues = values.filter(
+        (value) => value !== "msw/passthrough",
+      );
+
+      if (filteredValues.length > 0) {
+        headers.set("accept", filteredValues.join(", "));
+      } else {
+        headers.delete("accept");
+      }
+    }
+
+    return fetch(requestClone, { headers });
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough();
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough();
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request);
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: "REQUEST",
+      payload: {
+        id: requestId,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  );
+
+  switch (clientMessage.type) {
+    case "MOCK_RESPONSE": {
+      return respondWithMock(clientMessage.data);
+    }
+
+    case "PASSTHROUGH": {
+      return passthrough();
+    }
+  }
+
+  return passthrough();
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error);
+      }
+
+      resolve(event.data);
+    };
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ]);
+  });
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error();
+  }
+
+  const mockedResponse = new Response(response.body, response);
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  });
+
+  return mockedResponse;
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  };
+}

--- a/frontend/dashboard/src/RelayEnvironment.ts
+++ b/frontend/dashboard/src/RelayEnvironment.ts
@@ -8,20 +8,27 @@ import {
   GraphQLResponse,
   Observable,
 } from "relay-runtime";
-import keycloak from "./keycloak";
+import { getKeycloak } from "./keycloak";
 import { createClient } from "graphql-ws";
 
 const HTTP_ENDPOINT = import.meta.env.VITE_GRAPH_URL;
 const WS_ENDPOINT = import.meta.env.VITE_GRAPH_WS_URL;
+
+const keycloak = await getKeycloak();
 
 let kcinitPromise: Promise<boolean> | null = null;
 
 // needed to prevent repeated refresh of page when using subscriptions
 function ensureKeycloakInit(): Promise<boolean> {
   if (!kcinitPromise) {
-    kcinitPromise = keycloak.init({
-      onLoad: "login-required",
-    });
+    kcinitPromise = keycloak
+      .init({
+        onLoad: "login-required",
+      })
+      .catch((err: unknown) => {
+        console.error("Keycloak init failed", err);
+        return false;
+      });
   }
   return kcinitPromise;
 }

--- a/frontend/dashboard/src/keycloak.ts
+++ b/frontend/dashboard/src/keycloak.ts
@@ -1,12 +1,19 @@
 import Keycloak from "keycloak-js";
 
-//Keycloak init options
-const initOptions = {
-  url: import.meta.env.VITE_KEYCLOAK_URL,
-  realm: import.meta.env.VITE_KEYCLOAK_REALM,
-  clientId: import.meta.env.VITE_KEYCLOAK_CLIENT,
-};
+export async function getKeycloak() {
+  const isMocking = import.meta.env.VITE_ENABLE_MOCKING === "true";
 
-const keycloak = new Keycloak(initOptions);
+  if (isMocking) {
+    // only import when mocking
+    const mockKeycloak = await import("./mocks/mockKeycloak").then(
+      (mod) => mod.default,
+    );
+    return mockKeycloak;
+  }
 
-export default keycloak;
+  return new Keycloak({
+    url: import.meta.env.VITE_KEYCLOAK_URL,
+    realm: import.meta.env.VITE_KEYCLOAK_REALM,
+    clientId: import.meta.env.VITE_KEYCLOAK_CLIENT,
+  });
+}

--- a/frontend/dashboard/src/main.tsx
+++ b/frontend/dashboard/src/main.tsx
@@ -47,16 +47,25 @@ const router = createBrowserRouter([
   },
 ]);
 
+async function startMockingIfConfigured() {
+  if (import.meta.env.VITE_ENABLE_MOCKING === "true") {
+    const { worker } = await import("./mocks/browser");
+    return worker.start();
+  }
+}
+
 const root = createRoot(document.getElementById("root") as Element);
 
-void getRelayEnvironment().then((environment) => {
-  root.render(
-    <RelayEnvironmentProvider environment={environment}>
-      <StrictMode>
-        <ThemeProvider theme={DiamondTheme} defaultMode="light">
-          <RouterProvider router={router} />
-        </ThemeProvider>
-      </StrictMode>
-    </RelayEnvironmentProvider>,
-  );
+void startMockingIfConfigured().then(() => {
+  void getRelayEnvironment().then((environment) => {
+    root.render(
+      <RelayEnvironmentProvider environment={environment}>
+        <StrictMode>
+          <ThemeProvider theme={DiamondTheme} defaultMode="light">
+            <RouterProvider router={router} />
+          </ThemeProvider>
+        </StrictMode>
+      </RelayEnvironmentProvider>,
+    );
+  });
 });

--- a/frontend/dashboard/src/mocks/browser.ts
+++ b/frontend/dashboard/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/frontend/dashboard/src/mocks/handlers.ts
+++ b/frontend/dashboard/src/mocks/handlers.ts
@@ -1,0 +1,102 @@
+import { graphql, HttpResponse } from "msw";
+import {
+  RetriggerWorkflowQuery$data,
+  RetriggerWorkflowQuery$variables,
+} from "relay-workflows-lib/lib/components/__generated__/RetriggerWorkflowQuery.graphql";
+import {
+  TemplateViewMutation$data,
+  TemplateViewMutation$variables,
+} from "relay-workflows-lib/lib/components/__generated__/TemplateViewMutation.graphql";
+import {
+  TemplateViewQuery$data,
+  TemplateViewQuery$variables,
+} from "relay-workflows-lib/lib/components/__generated__/TemplateViewQuery.graphql";
+import {
+  workflowsQuery$data,
+  workflowsQuery$variables,
+} from "relay-workflows-lib/lib/graphql/__generated__/workflowsQuery.graphql";
+import {
+  TemplatesListQuery$data,
+  TemplatesListQuery$variables,
+} from "relay-workflows-lib/lib/components/__generated__/TemplatesListQuery.graphql";
+import templateListResponse from "./responses/templates/templateListResponse.json";
+import {
+  templateViewResponse,
+  templateFallbackResponse,
+} from "./responses/templates/templateResponses";
+import workflowsListResponse from "./responses/workflows/workflowsListResponse.json";
+import {
+  workflowRelayQuery$data,
+  workflowRelayQuery$variables,
+} from "relay-workflows-lib/lib/graphql/__generated__/workflowRelayQuery.graphql";
+import {
+  defaultWorkflowResponse,
+  workflowRelayMockResponses,
+} from "./responses/workflows/workflowResponses";
+
+const api = graphql.link("https://workflows.diamond.ac.uk/graphql");
+
+export const handlers = [
+  api.query<workflowsQuery$data, workflowsQuery$variables>(
+    "workflowsQuery",
+    () => {
+      return HttpResponse.json({
+        data: workflowsListResponse,
+      });
+    },
+  ),
+
+  api.query<workflowRelayQuery$data, workflowRelayQuery$variables>(
+    "workflowRelayQuery",
+    ({ variables }) => {
+      const response =
+        workflowRelayMockResponses[variables.name] ?? defaultWorkflowResponse;
+      return HttpResponse.json({ data: response });
+    },
+  ),
+
+  api.query<RetriggerWorkflowQuery$data, RetriggerWorkflowQuery$variables>(
+    "RetriggerWorkflowQuery",
+    ({ variables }) => {
+      return HttpResponse.json({
+        data: {
+          workflow: {
+            templateRef: `template-for-${variables.workflowname}`,
+          },
+        },
+      });
+    },
+  ),
+
+  api.query<TemplatesListQuery$data, TemplatesListQuery$variables>(
+    "TemplatesListQuery",
+    () => {
+      return HttpResponse.json({
+        data: templateListResponse,
+      });
+    },
+  ),
+
+  api.query<TemplateViewQuery$data, TemplateViewQuery$variables>(
+    "TemplateViewQuery",
+    ({ variables }) => {
+      const response =
+        templateViewResponse[variables.templateName] ??
+        templateFallbackResponse;
+      return HttpResponse.json({ data: response });
+    },
+  ),
+
+  api.mutation<TemplateViewMutation$data, TemplateViewMutation$variables>(
+    "TemplateViewMutation",
+    ({ variables }) => {
+      return HttpResponse.json({
+        data: {
+          submitWorkflowTemplate: {
+            name: `${variables.visit.proposalCode}-${variables.templateName}`,
+          },
+        },
+      });
+    },
+  ),
+];

--- a/frontend/dashboard/src/mocks/mockKeycloak.ts
+++ b/frontend/dashboard/src/mocks/mockKeycloak.ts
@@ -1,0 +1,24 @@
+const createMockJwt = (payload: object) => {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.signature`;
+};
+
+const mockToken = createMockJwt({
+  sub: "mock-user",
+  preferred_username: "mockuser",
+  email: "mock@diamond.ac.uk",
+  exp: Number.MAX_SAFE_INTEGER,
+  iat: Number.MIN_SAFE_INTEGER,
+  iss: "https://authn.diamond.ac.uk/realms/master",
+});
+
+const mockKeycloak = {
+  init: () => Promise.resolve(true),
+  authenticated: true,
+  token: mockToken,
+  updateToken: () => Promise.resolve(true),
+  onTokenExpired: () => {},
+};
+
+export default mockKeycloak;

--- a/frontend/dashboard/src/mocks/responses/templates/conditionalStepsTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/conditionalStepsTemplate.json
@@ -1,0 +1,13 @@
+{
+  "name": "conditional-steps",
+  "maintainer": "example-manifests-group",
+  "title": "conditional-steps",
+  "description": "Run steps based on conditions from previous outputs.\n",
+  "arguments": {
+    "properties": {},
+    "required": [],
+    "type": "object"
+  },
+  "uiSchema": null,
+  "repository": "https://github.com/DiamondLightSource/workflows"
+}

--- a/frontend/dashboard/src/mocks/responses/templates/e02Mib2xTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/e02Mib2xTemplate.json
@@ -1,0 +1,285 @@
+{
+  "name": "e02-mib2x",
+  "maintainer": "imaging-e02-group",
+  "title": "ePSIC mib conversion",
+  "description": "Convert MIB file to hdf5/hspy files\n",
+  "arguments": {
+    "properties": {
+      "DEBUG": {
+        "default": 1,
+        "type": "integer"
+      },
+      "Scan_X": {
+        "default": 256,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "Scan_Y": {
+        "default": 256,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "bin_nav_factor": {
+        "default": 4,
+        "maximum": 8,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "bin_sig_factor": {
+        "default": 4,
+        "maximum": 8,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "create_json": {
+        "default": false,
+        "type": "boolean"
+      },
+      "iBF": {
+        "default": true,
+        "type": "boolean"
+      },
+      "memory": {
+        "default": "16Gi",
+        "pattern": "^[0-9]+[GMK]i$",
+        "type": "string"
+      },
+      "mib_path": {
+        "type": "string"
+      },
+      "nprocs": {
+        "default": 8,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "ptycho_config": {
+        "default": "",
+        "type": "string"
+      },
+      "ptycho_template": {
+        "default": "",
+        "type": "string"
+      },
+      "reshape_option": {
+        "default": "--auto-reshape",
+        "oneOf": [
+          {
+            "const": "--auto-reshape",
+            "title": "Auto"
+          },
+          {
+            "const": "--no-reshaping",
+            "title": "None"
+          },
+          {
+            "const": "--use-fly-back",
+            "title": "Fly-back"
+          },
+          {
+            "const": "--known-shape",
+            "title": "By known shape"
+          }
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "DEBUG",
+      "Scan_X",
+      "Scan_Y",
+      "bin_nav_factor",
+      "bin_sig_factor",
+      "create_json",
+      "iBF",
+      "memory",
+      "mib_path",
+      "nprocs",
+      "ptycho_config",
+      "ptycho_template",
+      "reshape_option"
+    ],
+    "type": "object"
+  },
+  "uiSchema": {
+    "type": "VerticalLayout",
+    "elements": [
+      {
+        "type": "Group",
+        "label": "Input Files",
+        "elements": [
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Control",
+                "scope": "#/properties/mib_path",
+                "label": "Path of MIB file",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/iBF",
+                "label": "Generate integrated bright-field image",
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          }
+        ],
+        "options": null,
+        "rule": null
+      },
+      {
+        "type": "VerticalLayout",
+        "elements": [
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Group",
+                "label": "Reshape Options",
+                "elements": [
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/reshape_option",
+                    "label": "Reshape methods",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/Scan_X",
+                    "label": "Dimension in x (row)",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/Scan_Y",
+                    "label": "Dimension in y (column)",
+                    "options": null,
+                    "rule": null
+                  }
+                ],
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Group",
+                "label": "Pixel Binning",
+                "elements": [
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/bin_sig_factor",
+                    "label": "Signal binning factor (detector)",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/bin_nav_factor",
+                    "label": "Navigation binning factor",
+                    "options": null,
+                    "rule": null
+                  }
+                ],
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          },
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Group",
+                "label": "Configs for PtyREX",
+                "elements": [
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/create_json",
+                    "label": "Create PtyREX config",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/ptycho_config",
+                    "label": "The name of the generated config",
+                    "options": null,
+                    "rule": {
+                      "condition": {
+                        "schema": {
+                          "const": false
+                        },
+                        "scope": "#/properties/create_json"
+                      },
+                      "effect": "HIDE"
+                    }
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/ptycho_template",
+                    "label": "Path of the PtyREX template config",
+                    "options": null,
+                    "rule": {
+                      "condition": {
+                        "schema": {
+                          "const": false
+                        },
+                        "scope": "#/properties/create_json"
+                      },
+                      "effect": "HIDE"
+                    }
+                  }
+                ],
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Group",
+                "label": "Resource and Debug Settings",
+                "elements": [
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/nprocs",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/memory",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/DEBUG",
+                    "options": null,
+                    "rule": null
+                  }
+                ],
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          }
+        ],
+        "options": null,
+        "rule": null
+      }
+    ],
+    "options": {
+      "formWidth": "80%"
+    },
+    "rule": null
+  },
+  "repository": null
+}

--- a/frontend/dashboard/src/mocks/responses/templates/fallbackTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/fallbackTemplate.json
@@ -1,0 +1,54 @@
+{
+  "name": "fallback",
+  "maintainer": "example-manifests-group",
+  "title": "mock-template",
+  "description": "Use script step to transform inputs and dynamically create workflow steps.\n",
+  "arguments": {
+    "properties": {
+      "number": {
+        "default": 5,
+        "minimum": 1,
+        "type": "integer"
+      },
+      "start": {
+        "default": 2,
+        "type": "integer"
+      },
+      "stop": {
+        "default": 10,
+        "type": "integer"
+      }
+    },
+    "required": ["number", "start", "stop"],
+    "type": "object"
+  },
+  "uiSchema": {
+    "type": "VerticalLayout",
+    "elements": [
+      {
+        "type": "Control",
+        "scope": "#/properties/start",
+        "label": "Start",
+        "options": null,
+        "rule": null
+      },
+      {
+        "type": "Control",
+        "scope": "#/properties/stop",
+        "label": "Matrix Size",
+        "options": null,
+        "rule": null
+      },
+      {
+        "type": "Control",
+        "scope": "#/properties/number",
+        "label": "Number of outputs",
+        "options": null,
+        "rule": null
+      }
+    ],
+    "options": null,
+    "rule": null
+  },
+  "repository": "https://github.com/DiamondLightSource/workflows"
+}

--- a/frontend/dashboard/src/mocks/responses/templates/httomoCorSweepTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/httomoCorSweepTemplate.json
@@ -1,0 +1,629 @@
+{
+  "name": "httomo-cor-sweep",
+  "maintainer": "imaging-httomo-group",
+  "title": null,
+  "description": null,
+  "arguments": {
+    "properties": {
+      "config": {
+        "$defs": {
+          "EmptyDict": {
+            "description": "Empty dict representation",
+            "properties": {},
+            "title": "EmptyDict",
+            "type": "object"
+          },
+          "PreviewKeyword": {
+            "enum": ["begin", "mid", "end"],
+            "title": "PreviewKeyword",
+            "type": "string"
+          },
+          "PreviewParam": {
+            "description": "Preview configuration dict.",
+            "properties": {
+              "angles": {
+                "anyOf": [
+                  {
+                    "$ref": "#/properties/config/$defs/StartStopEntry"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "detector_x": {
+                "anyOf": [
+                  {
+                    "const": "mid",
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/properties/config/$defs/StartStopEntry"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Detector X"
+              },
+              "detector_y": {
+                "anyOf": [
+                  {
+                    "const": "mid",
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/properties/config/$defs/StartStopEntry"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Detector Y"
+              }
+            },
+            "title": "PreviewParam",
+            "type": "object"
+          },
+          "RawAngles": {
+            "description": "Configure rotation angle values to come from a dataset within the input NeXuS/hdf5 file.",
+            "properties": {
+              "data_path": {
+                "title": "Data Path",
+                "type": "string"
+              }
+            },
+            "required": ["data_path"],
+            "title": "RawAngles",
+            "type": "object"
+          },
+          "StandardTomoLoaderConfig": {
+            "description": "Standard tomo loader HTTomo config",
+            "properties": {
+              "method": {
+                "default": "standard_tomo",
+                "title": "Method",
+                "type": "string"
+              },
+              "module_path": {
+                "default": "httomo.data.hdf.loaders",
+                "title": "Module Path",
+                "type": "string"
+              },
+              "parameters": {
+                "$ref": "#/properties/config/$defs/StandardTomoLoaderParams"
+              }
+            },
+            "required": ["parameters"],
+            "title": "StandardTomoLoaderConfig",
+            "type": "object"
+          },
+          "StandardTomoLoaderParams": {
+            "description": "Parameters dict for HTTomo's standard tomo loader",
+            "properties": {
+              "data_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "const": "auto",
+                    "type": "string"
+                  }
+                ],
+                "title": "Data Path"
+              },
+              "image_key_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "const": "auto",
+                    "type": "string"
+                  }
+                ],
+                "title": "Image Key Path"
+              },
+              "preview": {
+                "anyOf": [
+                  {
+                    "$ref": "#/properties/config/$defs/PreviewParam"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "rotation_angles": {
+                "anyOf": [
+                  {
+                    "$ref": "#/properties/config/$defs/RawAngles"
+                  },
+                  {
+                    "$ref": "#/properties/config/$defs/UserDefinedAngles"
+                  },
+                  {
+                    "const": "auto",
+                    "type": "string"
+                  }
+                ],
+                "title": "Rotation Angles"
+              }
+            },
+            "required": ["data_path", "image_key_path", "rotation_angles"],
+            "title": "StandardTomoLoaderParams",
+            "type": "object"
+          },
+          "StartStopEntry": {
+            "description": "Configuration for a single dimension's previewing in terms of start/stop values.",
+            "properties": {
+              "start": {
+                "anyOf": [
+                  {
+                    "$ref": "#/properties/config/$defs/PreviewKeyword"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Start"
+              },
+              "start_offset": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Start Offset"
+              },
+              "stop": {
+                "anyOf": [
+                  {
+                    "$ref": "#/properties/config/$defs/PreviewKeyword"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Stop"
+              },
+              "stop_offset": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Stop Offset"
+              }
+            },
+            "title": "StartStopEntry",
+            "type": "object"
+          },
+          "SweepConfig": {
+            "description": "Parameter sweep config",
+            "properties": {
+              "start": {
+                "title": "Start",
+                "type": "integer"
+              },
+              "step": {
+                "default": 1,
+                "title": "Step",
+                "type": "integer"
+              },
+              "stop": {
+                "title": "Stop",
+                "type": "integer"
+              }
+            },
+            "required": ["start", "stop"],
+            "title": "SweepConfig",
+            "type": "object"
+          },
+          "TomopyMinusLogConfig": {
+            "description": "tomopy.prep.normalize.minus_log method config",
+            "properties": {
+              "method": {
+                "default": "minus_log",
+                "title": "Method",
+                "type": "string"
+              },
+              "module_path": {
+                "default": "tomopy.prep.normalize",
+                "title": "Module Path",
+                "type": "string"
+              },
+              "parameters": {
+                "$ref": "#/properties/config/$defs/EmptyDict",
+                "default": {}
+              },
+              "save_result": {
+                "default": false,
+                "title": "Save Result",
+                "type": "boolean"
+              }
+            },
+            "title": "TomopyMinusLogConfig",
+            "type": "object"
+          },
+          "TomopyNormalizeConfig": {
+            "description": "tomopy.prep.normalize.normalize method config",
+            "properties": {
+              "method": {
+                "default": "normalize",
+                "title": "Method",
+                "type": "string"
+              },
+              "module_path": {
+                "default": "tomopy.prep.normalize",
+                "title": "Module Path",
+                "type": "string"
+              },
+              "parameters": {
+                "$ref": "#/properties/config/$defs/TomopyNormalizeParams",
+                "default": {}
+              },
+              "save_result": {
+                "default": false,
+                "title": "Save Result",
+                "type": "boolean"
+              }
+            },
+            "title": "TomopyNormalizeConfig",
+            "type": "object"
+          },
+          "TomopyNormalizeParams": {
+            "description": "tomopy.prep.normalize.normalize parameters config",
+            "properties": {
+              "averaging": {
+                "anyOf": [
+                  {
+                    "const": "mean",
+                    "type": "string"
+                  },
+                  {
+                    "const": "median",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Averaging"
+              },
+              "cutoff": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Cutoff"
+              }
+            },
+            "required": ["cutoff", "averaging"],
+            "title": "TomopyNormalizeParams",
+            "type": "object"
+          },
+          "TomopyReconConfig": {
+            "description": "tomopy.recon.algorithm.recon method config",
+            "properties": {
+              "method": {
+                "default": "recon",
+                "title": "Method",
+                "type": "string"
+              },
+              "module_path": {
+                "default": "tomopy.recon.algorithm",
+                "title": "Module Path",
+                "type": "string"
+              },
+              "parameters": {
+                "$ref": "#/properties/config/$defs/TomopyReconConfigParams"
+              },
+              "save_result": {
+                "default": true,
+                "title": "Save Result",
+                "type": "boolean"
+              }
+            },
+            "required": ["parameters"],
+            "title": "TomopyReconConfig",
+            "type": "object"
+          },
+          "TomopyReconConfigParams": {
+            "description": "tomopy.recon.algorithm.recon parameters config",
+            "properties": {
+              "algorithm": {
+                "default": "gridrec",
+                "title": "Algorithm",
+                "type": "string"
+              },
+              "center": {
+                "$ref": "#/properties/config/$defs/SweepConfig"
+              },
+              "init_recon": {
+                "default": null,
+                "title": "Init Recon",
+                "type": "null"
+              },
+              "sinogram_order": {
+                "default": false,
+                "title": "Sinogram Order",
+                "type": "boolean"
+              }
+            },
+            "required": ["center"],
+            "title": "TomopyReconConfigParams",
+            "type": "object"
+          },
+          "UserDefinedAngles": {
+            "description": "Configure rotation angle values to be generated by specifying a start angle, stop angle,\nand the total number of angles.",
+            "properties": {
+              "angles_total": {
+                "title": "Angles Total",
+                "type": "integer"
+              },
+              "start_angle": {
+                "title": "Start Angle",
+                "type": "integer"
+              },
+              "stop_angle": {
+                "title": "Stop Angle",
+                "type": "integer"
+              }
+            },
+            "required": ["start_angle", "stop_angle", "angles_total"],
+            "title": "UserDefinedAngles",
+            "type": "object"
+          }
+        },
+        "description": "An HTTomo center-of-rotation parameter sweep pipeline",
+        "maxItems": 4,
+        "minItems": 4,
+        "prefixItems": [
+          {
+            "$ref": "#/properties/config/$defs/StandardTomoLoaderConfig"
+          },
+          {
+            "$ref": "#/properties/config/$defs/TomopyNormalizeConfig"
+          },
+          {
+            "$ref": "#/properties/config/$defs/TomopyMinusLogConfig"
+          },
+          {
+            "$ref": "#/properties/config/$defs/TomopyReconConfig"
+          }
+        ],
+        "title": "CorSweepPipeline",
+        "type": "array"
+      },
+      "httomo-outdir-name": {
+        "type": "string"
+      },
+      "input": {
+        "type": "string"
+      },
+      "memory": {
+        "default": "20Gi",
+        "pattern": "^[0-9]+[GMK]i$",
+        "type": "string"
+      },
+      "nprocs": {
+        "default": 1,
+        "type": "integer"
+      },
+      "output": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "config",
+      "httomo-outdir-name",
+      "input",
+      "memory",
+      "nprocs",
+      "output"
+    ],
+    "type": "object"
+  },
+  "uiSchema": {
+    "type": "VerticalLayout",
+    "elements": [
+      {
+        "type": "Group",
+        "label": "Workflow Parameters",
+        "elements": [
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Control",
+                "scope": "#/properties/input",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/output",
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          }
+        ],
+        "options": null,
+        "rule": null
+      },
+      {
+        "type": "Group",
+        "label": "Loader Configuration",
+        "elements": [
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Control",
+                "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/data_path/anyOf[0]",
+                "label": "Data Path",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/image_key_path/anyOf[0]",
+                "label": "Image Key Path",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/rotation_angles/anyOf[0]/properties/data_path",
+                "label": "Rotation Angles Path",
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          },
+          {
+            "type": "Group",
+            "label": "Preview",
+            "elements": [
+              {
+                "type": "HorizontalLayout",
+                "elements": [
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/preview/anyOf[0]/properties/detector_y/anyOf[1]/properties/start",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/preview/anyOf[0]/properties/detector_y/anyOf[1]/properties/stop",
+                    "options": null,
+                    "rule": null
+                  }
+                ],
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "HorizontalLayout",
+                "elements": [
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/preview/anyOf[0]/properties/detector_x/anyOf[1]/properties/start",
+                    "options": null,
+                    "rule": null
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/config/prefixItems[0]/properties/parameters/properties/preview/anyOf[0]/properties/detector_x/anyOf[1]/properties/stop",
+                    "options": null,
+                    "rule": null
+                  }
+                ],
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          }
+        ],
+        "options": null,
+        "rule": null
+      },
+      {
+        "type": "Group",
+        "label": "Parameter Sweep Configuration",
+        "elements": [
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Control",
+                "scope": "#/properties/config/prefixItems[3]/properties/parameters/properties/center/properties/start",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/config/prefixItems[3]/properties/parameters/properties/center/properties/stop",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/config/prefixItems[3]/properties/parameters/properties/center/properties/step",
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          }
+        ],
+        "options": null,
+        "rule": null
+      },
+      {
+        "type": "Group",
+        "label": "Advanced Configuration",
+        "elements": [
+          {
+            "type": "HorizontalLayout",
+            "elements": [
+              {
+                "type": "Control",
+                "scope": "#/properties/memory",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/nprocs",
+                "options": null,
+                "rule": null
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/httomo-outdir-name",
+                "options": null,
+                "rule": null
+              }
+            ],
+            "options": null,
+            "rule": null
+          }
+        ],
+        "options": null,
+        "rule": null
+      }
+    ],
+    "options": null,
+    "rule": null
+  },
+  "repository": null
+}

--- a/frontend/dashboard/src/mocks/responses/templates/notebookTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/notebookTemplate.json
@@ -1,0 +1,13 @@
+{
+  "name": "notebook",
+  "maintainer": "example-helm-group",
+  "title": null,
+  "description": null,
+  "arguments": {
+    "properties": {},
+    "required": [],
+    "type": "object"
+  },
+  "uiSchema": null,
+  "repository": null
+}

--- a/frontend/dashboard/src/mocks/responses/templates/ptychoTomoJobTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/ptychoTomoJobTemplate.json
@@ -1,0 +1,13 @@
+{
+  "name": "ptycho-tomo-job",
+  "maintainer": "imaging-i14-group",
+  "title": null,
+  "description": null,
+  "arguments": {
+    "properties": {},
+    "required": [],
+    "type": "object"
+  },
+  "uiSchema": null,
+  "repository": null
+}

--- a/frontend/dashboard/src/mocks/responses/templates/sinSimulateArtifactTemplate.json
+++ b/frontend/dashboard/src/mocks/responses/templates/sinSimulateArtifactTemplate.json
@@ -1,0 +1,26 @@
+{
+  "name": "sin-simulate-init",
+  "maintainer": "away-day-group",
+  "title": "Away Day",
+  "description": "Plots a sin curve for a given input.\n",
+  "arguments": {
+    "properties": {
+      "start": {
+        "default": "0",
+        "type": "string"
+      },
+      "step": {
+        "default": "1",
+        "type": "string"
+      },
+      "stop": {
+        "default": "10",
+        "type": "string"
+      }
+    },
+    "required": ["start", "step", "stop"],
+    "type": "object"
+  },
+  "uiSchema": null,
+  "repository": null
+}

--- a/frontend/dashboard/src/mocks/responses/templates/templateListResponse.json
+++ b/frontend/dashboard/src/mocks/responses/templates/templateListResponse.json
@@ -1,0 +1,202 @@
+{
+  "workflowTemplates": {
+    "nodes": [
+      {
+        "name": "conditional-steps",
+        "description": "Run steps based on conditions from previous outputs.\n",
+        "title": "conditional-steps",
+        "maintainer": "example-manifests-group",
+        "repository": "https://github.com/DiamondLightSource/workflows"
+      },
+      {
+        "name": "e02-auto-mib2x",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-e02-group",
+        "repository": null
+      },
+      {
+        "name": "e02-mib2x",
+        "description": "Convert MIB file to hdf5/hspy files\n",
+        "title": "ePSIC mib conversion",
+        "maintainer": "imaging-e02-group",
+        "repository": null
+      },
+      {
+        "name": "httomo-cor-sweep",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-httomo-group",
+        "repository": null
+      },
+      {
+        "name": "httomo-gpu-job",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-httomo-group",
+        "repository": null
+      },
+      {
+        "name": "looping-through-inputs",
+        "description": "Use script step to transform inputs and dynamically create workflow steps.\n",
+        "title": "using-loops",
+        "maintainer": "example-manifests-group",
+        "repository": "https://github.com/DiamondLightSource/workflows"
+      },
+      {
+        "name": "marimo-uv",
+        "description": "This is an example demo-ing the marimo with uv setup\n",
+        "title": "marimo-uv",
+        "maintainer": "spectroscopy-bluesky-group",
+        "repository": null
+      },
+      {
+        "name": "mmg-test-notebook",
+        "description": null,
+        "title": null,
+        "maintainer": "magnetic-materials-group",
+        "repository": null
+      },
+      {
+        "name": "mmg-test-python",
+        "description": null,
+        "title": null,
+        "maintainer": "magnetic-materials-group",
+        "repository": null
+      },
+      {
+        "name": "mount-tmpdir",
+        "description": null,
+        "title": null,
+        "maintainer": "example-manifests-group",
+        "repository": null
+      },
+      {
+        "name": "msmapper-notebook",
+        "description": "Runs the msmapper program to re-map detector images\nfrom i16 NeXus files into reciprocal lattice units.\n",
+        "title": "Reciprocal Space Mapper",
+        "maintainer": "magnetic-materials-group",
+        "repository": "https://github.com/DiamondLightSource/magnetic-materials-workflows"
+      },
+      {
+        "name": "notebook",
+        "description": null,
+        "title": null,
+        "maintainer": "example-helm-group",
+        "repository": null
+      },
+      {
+        "name": "notebook-with-input",
+        "description": null,
+        "title": null,
+        "maintainer": "example-helm-group",
+        "repository": null
+      },
+      {
+        "name": "numpy-benchmark",
+        "description": "Runs a numpy script in a python container.\nThe script finds the normal of the dot product of two random matrices.\nMatrix sizes are specified by the input parameter \"size\".\n",
+        "title": "Numpy Benchmark",
+        "maintainer": "example-manifests-group",
+        "repository": "https://github.com/DiamondLightSource/workflows"
+      },
+      {
+        "name": "nxstacker",
+        "description": "nxstacker is an utility to stack projections from different types of experiments to produce NeXus-compliance file(s).\n",
+        "title": "nxstacker",
+        "maintainer": "imaging-nxstacker-group",
+        "repository": null
+      },
+      {
+        "name": "ptycho-tomo-job",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-i14-group",
+        "repository": null
+      },
+      {
+        "name": "ptypy-cpu-job",
+        "description": "Runs a PtyPy reconstruction job inside a container.\n",
+        "title": "PtyPy CPU Job Submitter",
+        "maintainer": "imaging-ptypy-group",
+        "repository": null
+      },
+      {
+        "name": "ptypy-cpu-moonflower-benchmark",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-ptypy-group",
+        "repository": null
+      },
+      {
+        "name": "ptypy-gpu-job",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-ptypy-group",
+        "repository": null
+      },
+      {
+        "name": "ptypy-gpu-moonflower-benchmark",
+        "description": null,
+        "title": null,
+        "maintainer": "imaging-ptypy-group",
+        "repository": null
+      },
+      {
+        "name": "sin-simulate-artifact",
+        "description": "Plots a sin curve for a given input.\n",
+        "title": "Away Day",
+        "maintainer": "away-day-group",
+        "repository": null
+      },
+      {
+        "name": "sin-simulate-boilerplate",
+        "description": "Plots a sin curve for a given input.\n",
+        "title": "Away Day",
+        "maintainer": "away-day-group",
+        "repository": null
+      },
+      {
+        "name": "sin-simulate-init",
+        "description": "Plots a sin curve for a given input.\n",
+        "title": "Away Day",
+        "maintainer": "away-day-group",
+        "repository": null
+      },
+      {
+        "name": "sin-simulate-schema",
+        "description": "Plots a sin curve for a given input.\n",
+        "title": "Away Day",
+        "maintainer": "away-day-group",
+        "repository": null
+      },
+      {
+        "name": "sin-simulate-tmp-vol",
+        "description": "Plots a sin curve for a given input.\n",
+        "title": "Away Day",
+        "maintainer": "away-day-group",
+        "repository": null
+      },
+      {
+        "name": "using-cluster-templates",
+        "description": "Use pre-exisiting cluster-workflows as steps in your workflow.\n",
+        "title": "using-cluster-templates",
+        "maintainer": "example-manifests-group",
+        "repository": "https://github.com/DiamondLightSource/workflows"
+      },
+      {
+        "name": "visr",
+        "description": "Data processing for the Visible Light Spectroscopy beamline (ViSR).\n",
+        "title": "visr",
+        "maintainer": "visr-group",
+        "repository": null
+      },
+      {
+        "name": "xas-notebook",
+        "description": null,
+        "title": null,
+        "maintainer": "magnetic-materials-group",
+        "repository": null
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/templates/templateResponses.tsx
+++ b/frontend/dashboard/src/mocks/responses/templates/templateResponses.tsx
@@ -1,0 +1,40 @@
+import conditionalStepsTemplate from "./conditionalStepsTemplate.json";
+import e02Mib2xTemplate from "./e02Mib2xTemplate.json";
+import httomoCorSweepTemplate from "./httomoCorSweepTemplate.json";
+import fallbackTemplate from "./fallbackTemplate.json";
+import notebookTemplate from "./notebookTemplate.json";
+import ptychoTomoJobTemplate from "./ptychoTomoJobTemplate.json";
+import sinSimulateTemplate from "./sinSimulateArtifactTemplate.json";
+import { TemplateViewQuery$data } from "relay-workflows-lib/lib/components/__generated__/TemplateViewQuery.graphql";
+import type { workflowTemplateFragment$key } from "relay-workflows-lib/lib/graphql/__generated__/workflowTemplateFragment.graphql";
+
+export const templateViewResponse: Record<string, TemplateViewQuery$data> = {
+  "conditional-steps": {
+    workflowTemplate:
+      conditionalStepsTemplate as unknown as workflowTemplateFragment$key,
+  },
+  "e02-mib2x": {
+    workflowTemplate:
+      e02Mib2xTemplate as unknown as workflowTemplateFragment$key,
+  },
+  "httomo-cor-sweep": {
+    workflowTemplate:
+      httomoCorSweepTemplate as unknown as workflowTemplateFragment$key,
+  },
+  notebook: {
+    workflowTemplate:
+      notebookTemplate as unknown as workflowTemplateFragment$key,
+  },
+  "ptycho-tomo-job": {
+    workflowTemplate:
+      ptychoTomoJobTemplate as unknown as workflowTemplateFragment$key,
+  },
+  "sin-simulate-artifact": {
+    workflowTemplate:
+      sinSimulateTemplate as unknown as workflowTemplateFragment$key,
+  },
+};
+
+export const templateFallbackResponse: TemplateViewQuery$data = {
+  workflowTemplate: fallbackTemplate as unknown as workflowTemplateFragment$key,
+};

--- a/frontend/dashboard/src/mocks/responses/workflows/conditional-steps-first.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/conditional-steps-first.json
@@ -1,0 +1,89 @@
+{
+  "name": "conditional-steps-first",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "conditional-steps",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-22T10:35:22+00:00",
+    "endTime": "2025-08-22T10:35:43+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "conditional-steps-first-2863409095",
+        "name": "less-than-5",
+        "status": "SUCCEEDED",
+        "depends": ["conditional-steps-first-3687959097"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "conditional-steps-first-3687959097",
+        "name": "pick-a-number",
+        "status": "SUCCEEDED",
+        "depends": ["conditional-steps-first"],
+        "dependencies": [
+          "conditional-steps-first-567981434",
+          "conditional-steps-first-3590043386",
+          "conditional-steps-first-1223470002",
+          "conditional-steps-first-2863409095"
+        ],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "conditional-steps-first",
+        "name": "conditional-steps-first",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["conditional-steps-first-3687959097"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-first-567981434",
+        "name": "complex-condition",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-first-3687959097"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-first-1223470002",
+        "name": "greater-than-5",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-first-3687959097"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-first-3590043386",
+        "name": "even",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-first-3687959097"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/conditional-steps-second.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/conditional-steps-second.json
@@ -1,0 +1,89 @@
+{
+  "name": "conditional-steps-second",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "conditional-steps",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-05T17:06:00+00:00",
+    "endTime": "2025-08-05T17:06:20+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "conditional-steps-second-1851624235",
+        "name": "pick-a-number",
+        "status": "SUCCEEDED",
+        "depends": ["conditional-steps-second"],
+        "dependencies": [
+          "conditional-steps-second-757537572",
+          "conditional-steps-second-2546591724",
+          "conditional-steps-second-3106395740",
+          "conditional-steps-second-2942740785"
+        ],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "conditional-steps-second-2546591724",
+        "name": "even",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-second-1851624235"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-second-2942740785",
+        "name": "less-than-5",
+        "status": "SUCCEEDED",
+        "depends": ["conditional-steps-second-1851624235"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "conditional-steps-second",
+        "name": "conditional-steps-second",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["conditional-steps-second-1851624235"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-second-3106395740",
+        "name": "greater-than-5",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-second-1851624235"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-second-757537572",
+        "name": "complex-condition",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-second-1851624235"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/conditional-steps-third.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/conditional-steps-third.json
@@ -1,0 +1,89 @@
+{
+  "name": "conditional-steps-third",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "conditional-steps",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-19T09:45:55+00:00",
+    "endTime": "2025-08-19T09:46:26+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "conditional-steps-third-1746857061",
+        "name": "greater-than-5",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-third-3177968324"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-third-3903486903",
+        "name": "complex-condition",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-third-3177968324"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-third",
+        "name": "conditional-steps-third",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["conditional-steps-third-3177968324"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-third-3320442045",
+        "name": "even",
+        "status": "SKIPPED",
+        "depends": ["conditional-steps-third-3177968324"],
+        "dependencies": [],
+        "stepType": "Skipped",
+        "artifacts": []
+      },
+      {
+        "id": "conditional-steps-third-3545401330",
+        "name": "less-than-5",
+        "status": "SUCCEEDED",
+        "depends": ["conditional-steps-third-3177968324"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "conditional-steps-third-3177968324",
+        "name": "pick-a-number",
+        "status": "SUCCEEDED",
+        "depends": ["conditional-steps-third"],
+        "dependencies": [
+          "conditional-steps-third-3903486903",
+          "conditional-steps-third-3320442045",
+          "conditional-steps-third-1746857061",
+          "conditional-steps-third-3545401330"
+        ],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/mount-tmpdir-first.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/mount-tmpdir-first.json
@@ -1,0 +1,57 @@
+{
+  "name": "mount-tmpdir-first",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "mount-tmpdir",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-19T09:49:41+00:00",
+    "endTime": "2025-08-19T09:50:12+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "mount-tmpdir-first-2996578215",
+        "name": "read-shared-file",
+        "status": "SUCCEEDED",
+        "depends": ["mount-tmpdir-first-1553540662"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "mount-tmpdir-first-1553540662",
+        "name": "say-hello",
+        "status": "SUCCEEDED",
+        "depends": ["mount-tmpdir-first"],
+        "dependencies": ["mount-tmpdir-first-2996578215"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "mount-tmpdir-first",
+        "name": "mount-tmpdir-first",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["mount-tmpdir-first-1553540662"],
+        "stepType": "DAG",
+        "artifacts": []
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/notebook-first.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/notebook-first.json
@@ -1,0 +1,62 @@
+{
+  "name": "notebook-first",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "notebook",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-19T11:14:17+00:00",
+    "endTime": "2025-08-19T11:16:47+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "notebook-first-1461433281",
+        "name": "files",
+        "status": "SUCCEEDED",
+        "depends": ["notebook-first"],
+        "dependencies": ["notebook-first-1474563389"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "notebook-first",
+        "name": "notebook-first",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["notebook-first-1461433281"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "notebook-first-1474563389",
+        "name": "convert",
+        "status": "SUCCEEDED",
+        "depends": ["notebook-first-1461433281"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "notebook.html",
+            "url": "",
+            "mimeType": "text/html"
+          },
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/notebook-second.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/notebook-second.json
@@ -1,0 +1,62 @@
+{
+  "name": "notebook-second",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "notebook",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-21T18:12:48+00:00",
+    "endTime": "2025-08-21T18:14:50+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "notebook-second",
+        "name": "notebook-second",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["notebook-second-3790061711"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "notebook-second-3790061711",
+        "name": "files",
+        "status": "SUCCEEDED",
+        "depends": ["notebook-second"],
+        "dependencies": ["notebook-second-3005300287"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "notebook-second-3005300287",
+        "name": "convert",
+        "status": "SUCCEEDED",
+        "depends": ["notebook-second-3790061711"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "notebook.html",
+            "url": "",
+            "mimeType": "text/html"
+          },
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/ptycho-tomo-job-first.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/ptycho-tomo-job-first.json
@@ -1,0 +1,138 @@
+{
+  "name": "ptycho-tomo-job-first",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "ptycho-tomo-job",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-22T10:27:18+00:00",
+    "endTime": "2025-08-22T10:28:12+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "ptycho-tomo-job-first-2462835579",
+        "name": "ptycho-recons-2",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-first-2539189859"],
+        "dependencies": ["ptycho-tomo-job-first-670375061"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-first-620042204",
+        "name": "post-processing-1",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-first-2479613198"],
+        "dependencies": ["ptycho-tomo-job-first-1048220977"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-first-2479613198",
+        "name": "ptycho-recons-1",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-first-2539189859"],
+        "dependencies": ["ptycho-tomo-job-first-620042204"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-first-3788201106",
+        "name": "tomography",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-first-1048220977"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-first",
+        "name": "ptycho-tomo-job-first",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["ptycho-tomo-job-first-2539189859"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "ptycho-tomo-job-first-1048220977",
+        "name": "align",
+        "status": "SUCCEEDED",
+        "depends": [
+          "ptycho-tomo-job-first-620042204",
+          "ptycho-tomo-job-first-670375061"
+        ],
+        "dependencies": ["ptycho-tomo-job-first-3788201106"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-first-2539189859",
+        "name": "create-mask",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-first"],
+        "dependencies": [
+          "ptycho-tomo-job-first-2462835579",
+          "ptycho-tomo-job-first-2479613198"
+        ],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-first-670375061",
+        "name": "post-processing-2",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-first-2462835579"],
+        "dependencies": ["ptycho-tomo-job-first-1048220977"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/ptycho-tomo-job-second.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/ptycho-tomo-job-second.json
@@ -1,0 +1,138 @@
+{
+  "name": "ptycho-tomo-job-second",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "ptycho-tomo-job",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-22T10:27:22+00:00",
+    "endTime": "2025-08-22T10:28:15+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "ptycho-tomo-job-second-3248405604",
+        "name": "post-processing-2",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-second-1860025362"],
+        "dependencies": ["ptycho-tomo-job-second-229827508"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-second-229827508",
+        "name": "align",
+        "status": "SUCCEEDED",
+        "depends": [
+          "ptycho-tomo-job-second-3248405604",
+          "ptycho-tomo-job-second-3298738461"
+        ],
+        "dependencies": ["ptycho-tomo-job-second-4255670669"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-second-4255670669",
+        "name": "tomography",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-second-229827508"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-second-3199919166",
+        "name": "create-mask",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-second"],
+        "dependencies": [
+          "ptycho-tomo-job-second-1843247743",
+          "ptycho-tomo-job-second-1860025362"
+        ],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-second-3298738461",
+        "name": "post-processing-1",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-second-1843247743"],
+        "dependencies": ["ptycho-tomo-job-second-229827508"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-second",
+        "name": "ptycho-tomo-job-second",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["ptycho-tomo-job-second-3199919166"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "ptycho-tomo-job-second-1860025362",
+        "name": "ptycho-recons-2",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-second-3199919166"],
+        "dependencies": ["ptycho-tomo-job-second-3248405604"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-second-1843247743",
+        "name": "ptycho-recons-1",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-second-3199919166"],
+        "dependencies": ["ptycho-tomo-job-second-3298738461"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/ptycho-tomo-job-third.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/ptycho-tomo-job-third.json
@@ -1,0 +1,138 @@
+{
+  "name": "ptycho-tomo-job-third",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "ptycho-tomo-job",
+  "parameters": {},
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-22T10:18:00+00:00",
+    "endTime": "2025-08-22T10:18:52+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "ptycho-tomo-job-third",
+        "name": "ptycho-tomo-job-third",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": ["ptycho-tomo-job-third-590507507"],
+        "stepType": "DAG",
+        "artifacts": []
+      },
+      {
+        "id": "ptycho-tomo-job-third-3090693345",
+        "name": "align",
+        "status": "SUCCEEDED",
+        "depends": [
+          "ptycho-tomo-job-third-1406505733",
+          "ptycho-tomo-job-third-1356172876"
+        ],
+        "dependencies": ["ptycho-tomo-job-third-1763893730"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-third-1406505733",
+        "name": "post-processing-2",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-third-2991331627"],
+        "dependencies": ["ptycho-tomo-job-third-3090693345"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-third-590507507",
+        "name": "create-mask",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-third"],
+        "dependencies": [
+          "ptycho-tomo-job-third-2991331627",
+          "ptycho-tomo-job-third-3008109246"
+        ],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-third-1763893730",
+        "name": "tomography",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-third-3090693345"],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-third-1356172876",
+        "name": "post-processing-1",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-third-3008109246"],
+        "dependencies": ["ptycho-tomo-job-third-3090693345"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-third-2991331627",
+        "name": "ptycho-recons-2",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-third-590507507"],
+        "dependencies": ["ptycho-tomo-job-third-1406505733"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      },
+      {
+        "id": "ptycho-tomo-job-third-3008109246",
+        "name": "ptycho-recons-1",
+        "status": "SUCCEEDED",
+        "depends": ["ptycho-tomo-job-third-590507507"],
+        "dependencies": ["ptycho-tomo-job-third-1356172876"],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/sin-simulate-artifact-first.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/sin-simulate-artifact-first.json
@@ -1,0 +1,42 @@
+{
+  "name": "sin-simulate-artifact-first",
+  "visit": {
+    "proposalCode": "mg",
+    "proposalNumber": 36964,
+    "number": 1
+  },
+  "templateRef": "sin-simulate-artifact",
+  "parameters": {
+    "stop": "10",
+    "step": "1",
+    "start": "0"
+  },
+  "status": {
+    "__typename": "WorkflowSucceededStatus",
+    "startTime": "2025-08-19T09:47:26+00:00",
+    "endTime": "2025-08-19T09:47:58+00:00",
+    "message": null,
+    "tasks": [
+      {
+        "id": "sin-simulate-artifact-first",
+        "name": "sin-simulate-artifact-first",
+        "status": "SUCCEEDED",
+        "depends": [],
+        "dependencies": [],
+        "stepType": "Pod",
+        "artifacts": [
+          {
+            "name": "figure.png",
+            "url": "",
+            "mimeType": "image/png"
+          },
+          {
+            "name": "main.log",
+            "url": "",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/workflowResponses.tsx
+++ b/frontend/dashboard/src/mocks/responses/workflows/workflowResponses.tsx
@@ -1,0 +1,51 @@
+import { workflowRelayQuery$data } from "relay-workflows-lib/lib/graphql/__generated__/workflowRelayQuery.graphql";
+import conditionalStepsFirst from "./conditional-steps-first.json";
+import conditionalStepsSecond from "./conditional-steps-second.json";
+import conditionalStepsThird from "./conditional-steps-third.json";
+import mountTmpdirFirst from "./mount-tmpdir-first.json";
+import notebookFirst from "./notebook-first.json";
+import notebooksSecond from "./notebook-second.json";
+import ptychoTomoJobFirst from "./ptycho-tomo-job-first.json";
+import ptychoTomoJobSecond from "./ptycho-tomo-job-second.json";
+import ptychoTomoJobThird from "./ptycho-tomo-job-third.json";
+import sinSimulateArtifactFirst from "./sin-simulate-artifact-first.json";
+
+export const workflowRelayMockResponses: Record<
+  string,
+  workflowRelayQuery$data
+> = {
+  "conditional-steps-first": {
+    workflow: conditionalStepsFirst as workflowRelayQuery$data["workflow"],
+  },
+  "conditional-steps-second": {
+    workflow: conditionalStepsSecond as workflowRelayQuery$data["workflow"],
+  },
+  "conditional-steps-third": {
+    workflow: conditionalStepsThird as workflowRelayQuery$data["workflow"],
+  },
+  "mount-tmpdir-first": {
+    workflow: mountTmpdirFirst as workflowRelayQuery$data["workflow"],
+  },
+  "notebook-first": {
+    workflow: notebookFirst as workflowRelayQuery$data["workflow"],
+  },
+  "notebooks-second": {
+    workflow: notebooksSecond as workflowRelayQuery$data["workflow"],
+  },
+  "ptycho-tomo-job-first": {
+    workflow: ptychoTomoJobFirst as workflowRelayQuery$data["workflow"],
+  },
+  "ptycho-tomo-job-second": {
+    workflow: ptychoTomoJobSecond as workflowRelayQuery$data["workflow"],
+  },
+  "ptycho-tomo-job-third": {
+    workflow: ptychoTomoJobThird as workflowRelayQuery$data["workflow"],
+  },
+  "sin-simulate-artifact-first": {
+    workflow: sinSimulateArtifactFirst as workflowRelayQuery$data["workflow"],
+  },
+};
+
+export const defaultWorkflowResponse: workflowRelayQuery$data = {
+  workflow: conditionalStepsThird as workflowRelayQuery$data["workflow"],
+};

--- a/frontend/dashboard/src/mocks/responses/workflows/workflowsListResponse.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/workflowsListResponse.json
@@ -1,0 +1,42 @@
+{
+  "workflows": {
+    "nodes": [
+      {
+        "name": "conditional-steps-first"
+      },
+      {
+        "name": "conditional-steps-second"
+      },
+      {
+        "name": "conditional-steps-third"
+      },
+      {
+        "name": "mount-tmpdir-first"
+      },
+      {
+        "name": "notebook-first"
+      },
+      {
+        "name": "notebook-second"
+      },
+      {
+        "name": "ptycho-tomo-job-first"
+      },
+      {
+        "name": "ptycho-tomo-job-second"
+      },
+      {
+        "name": "ptycho-tomo-job-third"
+      },
+      {
+        "name": "sin-simulate-artifact-first"
+      }
+    ],
+    "pageInfo": {
+      "endCursor": "MTA",
+      "hasNextPage": true,
+      "hasPreviousPage": false,
+      "startCursor": "MQ"
+    }
+  }
+}

--- a/frontend/relay-workflows-lib/lib/components/BaseSingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/BaseSingleWorkflowView.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, ToggleButton } from "@mui/material";
+import { TaskInfo } from "workflows-lib/lib/components/workflow/TaskInfo";
+import { buildTaskTree } from "workflows-lib/lib/utils/tasksFlowUtils";
+import { Artifact, Task, TaskNode } from "workflows-lib/lib/types";
+import { useFetchedTasks, useSelectedTasks } from "./workflowRelayUtils";
+import WorkflowRelay from "./WorkflowRelay";
+import WorkflowInfo from "./WorkflowInfo";
+import { workflowRelaySubscription$data } from "../graphql/__generated__/workflowRelaySubscription.graphql";
+import { SingleWorkflowViewProps } from "./SingleWorkflowView";
+
+interface Props extends SingleWorkflowViewProps {
+  data: workflowRelaySubscription$data | null;
+}
+
+export default function BaseSingleWorkflowView({
+  visit,
+  workflowName,
+  tasknames,
+  data,
+}: Props) {
+  const [artifactList, setArtifactList] = useState<Artifact[]>([]);
+  const [outputTasks, setOutputTasks] = useState<string[]>([]);
+  const fetchedTasks = useFetchedTasks(data, visit, workflowName);
+  const [selectedTasks, setSelectedTasks] = useSelectedTasks();
+  const [filledTaskName, setFilledTaskName] = useState<string | null>(null);
+
+  const taskTree = useMemo(() => buildTaskTree(fetchedTasks), [fetchedTasks]);
+
+  const handleSelectOutput = () => {
+    setSelectedTasks(outputTasks);
+  };
+
+  const handleSelectClear = () => {
+    setSelectedTasks([]);
+  };
+
+  const onArtifactHover = useCallback(
+    (artifact: Artifact | null) => {
+      setFilledTaskName(artifact ? artifact.parentTask : null);
+    },
+    [setFilledTaskName],
+  );
+
+  useEffect(() => {
+    setSelectedTasks(tasknames ?? []);
+  }, [tasknames, setSelectedTasks]);
+
+  useEffect(() => {
+    const filteredTasks = selectedTasks.length
+      ? selectedTasks
+          .map((name) => fetchedTasks.find((task) => task.name === name))
+          .filter((task): task is Task => !!task)
+      : fetchedTasks;
+    setArtifactList(filteredTasks.flatMap((task) => task.artifacts));
+  }, [selectedTasks, fetchedTasks]);
+
+  useEffect(() => {
+    const newOutputTasks: string[] = [];
+    const traverse = (tasks: TaskNode[]) => {
+      const sortedTasks = [...tasks].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+      sortedTasks.forEach((taskNode) => {
+        if (
+          taskNode.children &&
+          taskNode.children.length === 0 &&
+          !newOutputTasks.includes(taskNode.name)
+        ) {
+          newOutputTasks.push(taskNode.name);
+        } else if (taskNode.children && taskNode.children.length > 0) {
+          traverse(taskNode.children);
+        }
+      });
+    };
+    traverse(taskTree);
+    setOutputTasks(newOutputTasks);
+  }, [taskTree]);
+
+  return (
+    <>
+      <Box
+        sx={{
+          position: "relative",
+          display: "inline-flex",
+          alignItems: "flex-start",
+          width: "100%",
+          height: "100%",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            width: "100%",
+            height: "100%",
+            gap: 2,
+          }}
+        >
+          <Box
+            display="flex"
+            flexDirection="column"
+            gap={1}
+            sx={{ position: "absolute", left: "-100px" }}
+          >
+            <ToggleButton
+              value="output"
+              aria-label="output"
+              onClick={handleSelectOutput}
+            >
+              OUTPUT
+            </ToggleButton>
+            <ToggleButton
+              value="output"
+              aria-label="output"
+              onClick={handleSelectClear}
+            >
+              CLEAR
+            </ToggleButton>
+          </Box>
+          {data && (
+            <WorkflowRelay
+              workflowName={data.workflow.name}
+              visit={data.workflow.visit}
+              workflowLink
+              filledTaskName={filledTaskName}
+              expanded={true}
+            />
+          )}
+        </Box>
+      </Box>
+      {tasknames && (
+        <TaskInfo
+          artifactList={artifactList}
+          onArtifactHover={onArtifactHover}
+        />
+      )}
+      {data && <WorkflowInfo workflow={data.workflow} />}
+    </>
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/BaseWorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/BaseWorkflowRelay.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { ResizableBox } from "react-resizable";
+import { Box } from "@mui/material";
+import { Visit, visitToText } from "@diamondlightsource/sci-react-ui";
+import {
+  TasksFlow,
+  WorkflowAccordion,
+  type WorkflowStatus,
+} from "workflows-lib";
+import RetriggerWorkflow from "./RetriggerWorkflow";
+import { useFetchedTasks, useSelectedTasks } from "./workflowRelayUtils";
+import { workflowRelaySubscription$data } from "../graphql/__generated__/workflowRelaySubscription.graphql";
+import { useParams, useNavigate } from "react-router-dom";
+
+interface Props {
+  visit: Visit;
+  workflowName: string;
+  workflowLink?: boolean;
+  filledTaskName?: string | null;
+  expanded?: boolean;
+  onChange?: () => void;
+  data: workflowRelaySubscription$data | null;
+}
+
+export default function BaseWorkflowRelay({
+  visit,
+  workflowName,
+  workflowLink,
+  filledTaskName,
+  expanded,
+  onChange,
+  data,
+}: Props) {
+  const { workflowName: workflowNameURL } = useParams<{
+    workflowName: string;
+  }>();
+  const navigate = useNavigate();
+  const statusText = data?.workflow.status?.__typename ?? "Unknown";
+  const fetchedTasks = useFetchedTasks(data, visit, workflowName);
+  const [selectedTasks, setSelectedTasks] = useSelectedTasks();
+
+  const onNavigate = React.useCallback(
+    (path: string, event?: React.MouseEvent) => {
+      const taskName = String(path.split("/").filter(Boolean).pop());
+      const isCtrl = event?.ctrlKey || event?.metaKey;
+
+      let updatedTasks: string[];
+
+      if (isCtrl) {
+        updatedTasks = selectedTasks.includes(taskName)
+          ? selectedTasks.filter((name) => name !== taskName)
+          : [...selectedTasks, taskName];
+      } else {
+        updatedTasks = [taskName];
+      }
+      if (workflowNameURL !== workflowName) {
+        void navigate(`/workflows/${visitToText(visit)}/${workflowName}`);
+      }
+      setSelectedTasks(updatedTasks);
+    },
+    [
+      navigate,
+      selectedTasks,
+      setSelectedTasks,
+      visit,
+      workflowName,
+      workflowNameURL,
+    ],
+  );
+
+  return (
+    <Box
+      sx={{
+        width: {
+          xl: "100%",
+          lg: "100%",
+          md: "90%",
+          sm: "80%",
+          xs: "70%",
+        },
+        maxWidth: "1200px",
+        height: "100%",
+        mx: "auto",
+      }}
+    >
+      <WorkflowAccordion
+        workflow={{
+          name: workflowName,
+          instrumentSession: visit,
+          status: statusText as WorkflowStatus,
+        }}
+        workflowLink={workflowLink}
+        expanded={expanded}
+        onChange={onChange}
+        retriggerComponent={RetriggerWorkflow}
+      >
+        <ResizableBox
+          width={Infinity}
+          height={200}
+          resizeHandles={["se"]}
+          style={{
+            width: "100%",
+            maxWidth: "1150px",
+            minWidth: "300px",
+            padding: "10px",
+            overflow: "auto",
+            border: "2px dashed #ccc",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <TasksFlow
+            workflowName={workflowName}
+            tasks={fetchedTasks}
+            onNavigate={onNavigate}
+            highlightedTaskNames={selectedTasks}
+            filledTaskName={filledTaskName}
+          />
+        </ResizableBox>
+      </WorkflowAccordion>
+    </Box>
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/LiveSingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/LiveSingleWorkflowView.tsx
@@ -1,0 +1,48 @@
+import { useState, useMemo } from "react";
+import { useSubscription } from "react-relay";
+import { GraphQLSubscriptionConfig } from "relay-runtime";
+import {
+  workflowRelaySubscription$data,
+  workflowRelaySubscription as WorkflowRelaySubscriptionType,
+} from "../graphql/__generated__/workflowRelaySubscription.graphql";
+import { workflowRelaySubscription } from "../graphql/workflowRelaySubscription";
+import BaseSingleWorkflowView from "./BaseSingleWorkflowView";
+import { SingleWorkflowViewProps } from "./SingleWorkflowView";
+
+export default function LiveWorkflowView({
+  visit,
+  workflowName,
+  tasknames,
+}: SingleWorkflowViewProps) {
+  const [workflowData, setWorkflowData] =
+    useState<workflowRelaySubscription$data | null>(null);
+
+  const subscriptionData: GraphQLSubscriptionConfig<WorkflowRelaySubscriptionType> =
+    useMemo(
+      () => ({
+        subscription: workflowRelaySubscription,
+        variables: { visit, name: workflowName },
+        onNext: (res) => {
+          setWorkflowData(res ?? null);
+        },
+        onError: (error: unknown) => {
+          console.error("Subscription error:", error);
+        },
+        onCompleted: () => {
+          console.log("completed");
+        },
+      }),
+      [visit, workflowName],
+    );
+
+  useSubscription(subscriptionData);
+
+  return (
+    <BaseSingleWorkflowView
+      visit={visit}
+      workflowName={workflowName}
+      tasknames={tasknames}
+      data={workflowData}
+    />
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/LiveWorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/LiveWorkflowRelay.tsx
@@ -1,0 +1,40 @@
+import { useMemo, useState } from "react";
+import { useSubscription } from "react-relay";
+import { workflowRelaySubscription } from "../graphql/workflowRelaySubscription";
+import {
+  workflowRelaySubscription$data,
+  workflowRelaySubscription as WorkflowRelaySubscriptionType,
+} from "../graphql/__generated__/workflowRelaySubscription.graphql";
+import BaseWorkflowRelay from "./BaseWorkflowRelay";
+import { WorkflowRelayProps } from "./WorkflowRelay";
+
+export default function LiveWorkflowRelay(props: WorkflowRelayProps) {
+  const [workflowData, setWorkflowData] =
+    useState<workflowRelaySubscription$data | null>(null);
+
+  const subscriptionConfig = useMemo(
+    () => ({
+      subscription: workflowRelaySubscription,
+      variables: {
+        visit: props.visit,
+        name: props.workflowName,
+      },
+      onNext: (response?: workflowRelaySubscription$data | null) => {
+        if (response) {
+          setWorkflowData(response);
+        }
+      },
+      onError: (error: unknown) => {
+        console.error("Subscription error:", error);
+      },
+      onCompleted: () => {
+        console.log("completed");
+      },
+    }),
+    [props.visit, props.workflowName],
+  );
+
+  useSubscription<WorkflowRelaySubscriptionType>(subscriptionConfig);
+
+  return <BaseWorkflowRelay {...props} data={workflowData} />;
+}

--- a/frontend/relay-workflows-lib/lib/components/MockedSingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/MockedSingleWorkflowView.tsx
@@ -1,0 +1,28 @@
+import { useLazyLoadQuery } from "react-relay";
+import { workflowRelayQuery } from "../graphql/workflowRelayQuery";
+import BaseSingleWorkflowView from "./BaseSingleWorkflowView";
+import { workflowRelayQuery as WorkflowRelayQueryType } from "../graphql/__generated__/workflowRelayQuery.graphql";
+import { SingleWorkflowViewProps } from "./SingleWorkflowView";
+
+export default function MockedWorkflowView({
+  visit,
+  workflowName,
+  tasknames,
+}: SingleWorkflowViewProps) {
+  const queryData = useLazyLoadQuery<WorkflowRelayQueryType>(
+    workflowRelayQuery,
+    {
+      visit,
+      name: workflowName,
+    },
+  );
+
+  return (
+    <BaseSingleWorkflowView
+      visit={visit}
+      workflowName={workflowName}
+      tasknames={tasknames}
+      data={queryData}
+    />
+  );
+}

--- a/frontend/relay-workflows-lib/lib/components/MockedWorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/MockedWorkflowRelay.tsx
@@ -1,0 +1,17 @@
+import { useLazyLoadQuery } from "react-relay";
+import { workflowRelayQuery } from "../graphql/workflowRelayQuery";
+import { workflowRelayQuery as WorkflowRelayQueryType } from "../graphql/__generated__/workflowRelayQuery.graphql";
+import BaseWorkflowRelay from "./BaseWorkflowRelay";
+import { WorkflowRelayProps } from "./WorkflowRelay";
+
+export default function MockedWorkflowRelay(props: WorkflowRelayProps) {
+  const queryData = useLazyLoadQuery<WorkflowRelayQueryType>(
+    workflowRelayQuery,
+    {
+      visit: props.visit,
+      name: props.workflowName,
+    },
+  );
+
+  return <BaseWorkflowRelay {...props} data={queryData} />;
+}

--- a/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
+++ b/frontend/relay-workflows-lib/lib/components/SingleWorkflowView.tsx
@@ -1,170 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useSubscription } from "react-relay";
-import { GraphQLSubscriptionConfig } from "relay-runtime";
-import { Box, ToggleButton } from "@mui/material";
-import { Visit } from "@diamondlightsource/sci-react-ui";
-import { TaskInfo } from "workflows-lib/lib/components/workflow/TaskInfo";
-import { buildTaskTree } from "workflows-lib/lib/utils/tasksFlowUtils";
-import { Artifact, Task, TaskNode } from "workflows-lib/lib/types";
-import { useFetchedTasks, useSelectedTasks } from "./workflowRelayUtils";
-import WorkflowRelay from "./WorkflowRelay";
-import WorkflowInfo from "./WorkflowInfo";
-import { workflowRelaySubscription } from "../graphql/workflowRelaySubscription";
-import {
-  workflowRelaySubscription$data,
-  workflowRelaySubscription as WorkflowRelaySubscriptionType,
-} from "../graphql/__generated__/workflowRelaySubscription.graphql";
+import { Visit } from "workflows-lib";
+import LiveSingleWorkflowView from "./LiveSingleWorkflowView";
+import MockedWorkflowView from "./MockedSingleWorkflowView";
 
-interface SingleWorkflowViewProps {
+const isMocking = import.meta.env.VITE_ENABLE_MOCKING === "true";
+export interface SingleWorkflowViewProps {
   visit: Visit;
   workflowName: string;
   tasknames?: string[];
 }
 
-export default function SingleWorkflowView({
-  visit,
-  workflowName,
-  tasknames,
-}: SingleWorkflowViewProps) {
-  const [workflowData, setWorkflowData] =
-    React.useState<workflowRelaySubscription$data | null>(null);
-
-  const subscriptionData: GraphQLSubscriptionConfig<WorkflowRelaySubscriptionType> =
-    useMemo(
-      () => ({
-        subscription: workflowRelaySubscription,
-        variables: {
-          visit,
-          name: workflowName,
-        },
-        onNext: (res?: workflowRelaySubscription$data | null) => {
-          setWorkflowData(res ?? null);
-        },
-        onError: () => {},
-        onCompleted: () => {},
-      }),
-      [visit, workflowName],
-    );
-
-  useSubscription(subscriptionData);
-
-  const [artifactList, setArtifactList] = useState<Artifact[]>([]);
-  const [outputTasks, setOutputTasks] = useState<string[]>([]);
-  const fetchedTasks = useFetchedTasks(workflowData, visit, workflowName);
-  const [selectedTasks, setSelectedTasks] = useSelectedTasks();
-  const [filledTaskName, setFilledTaskName] = useState<string | null>(null);
-
-  const taskTree = useMemo(() => buildTaskTree(fetchedTasks), [fetchedTasks]);
-
-  const handleSelectOutput = () => {
-    setSelectedTasks(outputTasks);
-  };
-
-  const handleSelectClear = () => {
-    setSelectedTasks([]);
-  };
-
-  const onArtifactHover = useCallback(
-    (artifact: Artifact | null) => {
-      setFilledTaskName(artifact ? artifact.parentTask : null);
-    },
-    [setFilledTaskName],
-  );
-
-  useEffect(() => {
-    setSelectedTasks(tasknames ? tasknames : []);
-  }, [tasknames, setSelectedTasks]);
-
-  useEffect(() => {
-    const filteredTasks = selectedTasks.length
-      ? selectedTasks
-          .map((name) => fetchedTasks.find((task) => task.name === name))
-          .filter((task): task is Task => !!task)
-      : fetchedTasks;
-    setArtifactList(filteredTasks.flatMap((task) => task.artifacts));
-  }, [selectedTasks, fetchedTasks]);
-
-  useEffect(() => {
-    const newOutputTasks: string[] = [];
-    const traverse = (tasks: TaskNode[]) => {
-      const sortedTasks = [...tasks].sort((a, b) =>
-        a.name.localeCompare(b.name),
-      );
-      sortedTasks.forEach((taskNode) => {
-        if (
-          taskNode.children &&
-          taskNode.children.length == 0 &&
-          !newOutputTasks.includes(taskNode.name)
-        ) {
-          newOutputTasks.push(taskNode.name);
-        } else if (taskNode.children && taskNode.children.length > 0) {
-          traverse(taskNode.children);
-        }
-      });
-    };
-    traverse(taskTree);
-    setOutputTasks(newOutputTasks);
-  }, [taskTree]);
-
-  return (
-    <>
-      <Box
-        sx={{
-          position: "relative",
-          display: "inline-flex",
-          alignItems: "flex-start",
-          width: "100%",
-          height: "100%",
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            width: "100%",
-            height: "100%",
-            gap: 2,
-          }}
-        >
-          <Box
-            display="flex"
-            flexDirection="column"
-            gap={1}
-            sx={{ position: "absolute", left: "-100px" }}
-          >
-            <ToggleButton
-              value="output"
-              aria-label="output"
-              onClick={handleSelectOutput}
-            >
-              OUTPUT
-            </ToggleButton>
-            <ToggleButton
-              value="output"
-              aria-label="output"
-              onClick={handleSelectClear}
-            >
-              CLEAR
-            </ToggleButton>
-          </Box>
-          {workflowData && (
-            <WorkflowRelay
-              workflowName={workflowData.workflow.name}
-              visit={workflowData.workflow.visit}
-              workflowLink
-              filledTaskName={filledTaskName}
-              expanded={true}
-            />
-          )}
-        </Box>
-      </Box>
-      {tasknames && (
-        <TaskInfo
-          artifactList={artifactList}
-          onArtifactHover={onArtifactHover}
-        />
-      )}
-      {workflowData && <WorkflowInfo workflow={workflowData.workflow} />}
-    </>
+export default function SingleWorkflowView(props: SingleWorkflowViewProps) {
+  return isMocking ? (
+    <MockedWorkflowView {...props} />
+  ) : (
+    <LiveSingleWorkflowView {...props} />
   );
 }

--- a/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
+++ b/frontend/relay-workflows-lib/lib/components/WorkflowRelay.tsx
@@ -1,22 +1,8 @@
 import React from "react";
-import { useSubscription } from "react-relay";
-import { ResizableBox } from "react-resizable";
-import "react-resizable/css/styles.css";
-import { useParams, useNavigate } from "react-router-dom";
-import { Box } from "@mui/material";
-import { Visit, visitToText } from "@diamondlightsource/sci-react-ui";
-import {
-  TasksFlow,
-  WorkflowAccordion,
-  type WorkflowStatus,
-} from "workflows-lib";
-import RetriggerWorkflow from "./RetriggerWorkflow";
-import { useFetchedTasks, useSelectedTasks } from "./workflowRelayUtils";
-import { workflowRelaySubscription } from "../graphql/workflowRelaySubscription.ts";
-import { workflowRelaySubscription$data } from "../graphql/__generated__/workflowRelaySubscription.graphql";
-import { workflowRelaySubscription as WorkflowRelaySubscriptionType } from "../graphql/__generated__/workflowRelaySubscription.graphql";
-
-interface WorkflowRelayProps {
+import MockedWorkflowRelay from "./MockedWorkflowRelay";
+import LiveWorkflowRelay from "./LiveWorkflowRelay";
+import { Visit } from "workflows-lib";
+export interface WorkflowRelayProps {
   visit: Visit;
   workflowName: string;
   workflowLink?: boolean;
@@ -25,122 +11,13 @@ interface WorkflowRelayProps {
   onChange?: () => void;
 }
 
-const WorkflowRelay: React.FC<WorkflowRelayProps> = ({
-  visit,
-  workflowName,
-  workflowLink,
-  filledTaskName,
-  expanded,
-  onChange,
-}) => {
-  const [workflowData, setWorkflowData] =
-    React.useState<workflowRelaySubscription$data | null>(null);
+const isMocking = import.meta.env.VITE_ENABLE_MOCKING === "true";
 
-  useSubscription<WorkflowRelaySubscriptionType>({
-    subscription: workflowRelaySubscription,
-    variables: {
-      visit: visit,
-      name: workflowName,
-    },
-    onNext: (response?: workflowRelaySubscription$data | null) => {
-      if (response) {
-        setWorkflowData(response);
-      }
-    },
-    onError: (error) => {
-      console.error("Subscription error:", error);
-    },
-  });
-
-  const { workflowName: workflowNameURL } = useParams<{
-    workflowName: string;
-  }>();
-  const navigate = useNavigate();
-  const statusText = workflowData?.workflow.status?.__typename ?? "Unknown";
-  const fetchedTasks = useFetchedTasks(workflowData, visit, workflowName);
-  const [selectedTasks, setSelectedTasks] = useSelectedTasks();
-
-  const onNavigate = React.useCallback(
-    (path: string, event?: React.MouseEvent) => {
-      const taskName = String(path.split("/").filter(Boolean).pop());
-      const isCtrl = event?.ctrlKey || event?.metaKey;
-
-      let updatedTasks: string[];
-
-      if (isCtrl) {
-        updatedTasks = selectedTasks.includes(taskName)
-          ? selectedTasks.filter((name) => name !== taskName)
-          : [...selectedTasks, taskName];
-      } else {
-        updatedTasks = [taskName];
-      }
-      if (workflowNameURL !== workflowName) {
-        void navigate(`/workflows/${visitToText(visit)}/${workflowName}`);
-      }
-      setSelectedTasks(updatedTasks);
-    },
-    [
-      navigate,
-      selectedTasks,
-      setSelectedTasks,
-      visit,
-      workflowName,
-      workflowNameURL,
-    ],
-  );
-
-  return (
-    <Box
-      sx={{
-        width: {
-          xl: "100%",
-          lg: "100%",
-          md: "90%",
-          sm: "80%",
-          xs: "70%",
-        },
-        maxWidth: "1200px",
-        height: "100%",
-        mx: "auto",
-      }}
-    >
-      <WorkflowAccordion
-        workflow={{
-          name: workflowName,
-          instrumentSession: visit,
-          status: statusText as WorkflowStatus,
-        }}
-        workflowLink={workflowLink}
-        expanded={expanded}
-        onChange={onChange}
-        retriggerComponent={RetriggerWorkflow}
-      >
-        <ResizableBox
-          width={Infinity}
-          height={200}
-          resizeHandles={["se"]}
-          style={{
-            width: "100%",
-            maxWidth: "1150px",
-            minWidth: "300px",
-            padding: "10px",
-            overflow: "auto",
-            border: "2px dashed #ccc",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <TasksFlow
-            workflowName={workflowName}
-            tasks={fetchedTasks}
-            onNavigate={onNavigate}
-            highlightedTaskNames={selectedTasks}
-            filledTaskName={filledTaskName}
-          ></TasksFlow>
-        </ResizableBox>
-      </WorkflowAccordion>
-    </Box>
+const WorkflowRelay: React.FC<WorkflowRelayProps> = (props) => {
+  return isMocking ? (
+    <MockedWorkflowRelay {...props} />
+  ) : (
+    <LiveWorkflowRelay {...props} />
   );
 };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -296,6 +296,28 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
+"@bundled-es-modules/cookie@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz#b41376af6a06b3e32a15241d927b840a9b4de507"
+  integrity sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==
+  dependencies:
+    cookie "^0.7.2"
+
+"@bundled-es-modules/statuses@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz#761d10f44e51a94902c4da48675b71a76cc98872"
+  integrity sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==
+  dependencies:
+    statuses "^2.0.1"
+
+"@bundled-es-modules/tough-cookie@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz#fa9cd3cedfeecd6783e8b0d378b4a99e52bde5d3"
+  integrity sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==
+  dependencies:
+    "@types/tough-cookie" "^4.0.5"
+    tough-cookie "^4.1.4"
+
 "@chromatic-com/storybook@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@chromatic-com/storybook/-/storybook-4.1.1.tgz#6d67bb64380655887ece1d54561b6f056a3bb513"
@@ -692,6 +714,38 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.2.tgz#1860473de7dfa1546767448f333db80cb0ff2161"
   integrity sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==
 
+"@inquirer/confirm@^5.0.0":
+  version "5.1.15"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-5.1.15.tgz#c502d5c642fdba0669b17442b40794c97bdbccb4"
+  integrity sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==
+  dependencies:
+    "@inquirer/core" "^10.1.15"
+    "@inquirer/type" "^3.0.8"
+
+"@inquirer/core@^10.1.15":
+  version "10.1.15"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-10.1.15.tgz#8feb69fd536786181a2b6bfb84d8674faa9d2e59"
+  integrity sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==
+  dependencies:
+    "@inquirer/figures" "^1.0.13"
+    "@inquirer/type" "^3.0.8"
+    ansi-escapes "^4.3.2"
+    cli-width "^4.1.0"
+    mute-stream "^2.0.0"
+    signal-exit "^4.1.0"
+    wrap-ansi "^6.2.0"
+    yoctocolors-cjs "^2.1.2"
+
+"@inquirer/figures@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-1.0.13.tgz#ad0afd62baab1c23175115a9b62f511b6a751e45"
+  integrity sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==
+
+"@inquirer/type@^3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.8.tgz#efc293ba0ed91e90e6267f1aacc1c70d20b8b4e8"
+  integrity sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -839,6 +893,18 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
+"@mswjs/interceptors@^0.39.1":
+  version "0.39.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.39.6.tgz#44094a578f20da4749d1a0eaf3cdb7973604004b"
+  integrity sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
+
 "@mui/core-downloads-tracker@^6.4.8":
   version "6.4.8"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.8.tgz#ffabbdce0e7b341e9c2906bb06a00b34c9d15e05"
@@ -967,6 +1033,24 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0", "@open-draft/until@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1254,6 +1338,11 @@
   dependencies:
     "@types/deep-eql" "*"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/d3-color@*":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
@@ -1416,6 +1505,16 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/statuses@^2.0.4":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.6.tgz#66748315cc9a96d63403baa8671b2c124f8633aa"
+  integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
+
+"@types/tough-cookie@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -1684,6 +1783,13 @@ ajv@^8.0.0, ajv@^8.17.1, ajv@^8.6.1:
     fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
+
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -2063,6 +2169,20 @@ classcat@^5.0.3:
   resolved "https://registry.yarnpkg.com/classcat/-/classcat-5.0.5.tgz#8c209f359a93ac302404a10161b501eba9c09c77"
   integrity sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==
 
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
@@ -2099,6 +2219,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookie@^1.0.1:
   version "1.0.2"
@@ -2672,7 +2797,7 @@ esbuild-register@^3.5.0:
     "@esbuild/win32-ia32" "0.25.0"
     "@esbuild/win32-x64" "0.25.0"
 
-escalade@^3.2.0:
+escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -3026,6 +3151,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
@@ -3176,6 +3306,11 @@ graphql@15.3.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
   integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
 
+graphql@^16.8.1:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
+  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
+
 harmony-reflect@^1.4.6:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
@@ -3233,6 +3368,11 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+headers-polyfill@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
+  integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -3491,6 +3631,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -3982,6 +4127,35 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^2.10.5:
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-2.10.5.tgz#3e43f12e97581c260bf38d8817732b9fec3bfdb0"
+  integrity sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A==
+  dependencies:
+    "@bundled-es-modules/cookie" "^2.0.1"
+    "@bundled-es-modules/statuses" "^1.0.1"
+    "@bundled-es-modules/tough-cookie" "^0.1.6"
+    "@inquirer/confirm" "^5.0.0"
+    "@mswjs/interceptors" "^0.39.1"
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/until" "^2.1.0"
+    "@types/cookie" "^0.6.0"
+    "@types/statuses" "^2.0.4"
+    graphql "^16.8.1"
+    headers-polyfill "^4.0.2"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    strict-event-emitter "^0.5.1"
+    type-fest "^4.26.1"
+    yargs "^17.7.2"
+
+mute-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-2.0.0.tgz#a5446fc0c512b71c83c44d908d5c7b7b4c493b2b"
+  integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
+
 nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
@@ -4102,6 +4276,11 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
 own-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.1.tgz#e4006910a2bf913585289676eebd6f390cf51358"
@@ -4204,6 +4383,11 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -4292,10 +4476,22 @@ prop-types@15.x, prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-punycode@^2.1.0, punycode@^2.3.1:
+psl@^1.1.33:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -4494,10 +4690,20 @@ relay-runtime@20.1.1, relay-runtime@^20.0.0:
     fbjs "^3.0.2"
     invariant "^2.2.4"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -4762,7 +4968,7 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -4804,6 +5010,11 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
+statuses@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
 std-env@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
@@ -4827,6 +5038,11 @@ storybook@^9.1.3:
     semver "^7.6.2"
     ws "^8.18.0"
 
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -4836,7 +5052,7 @@ storybook@^9.1.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5063,6 +5279,16 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tough-cookie@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tough-cookie@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
@@ -5112,6 +5338,16 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^4.26.1:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 typed-array-buffer@^1.0.2:
   version "1.0.2"
@@ -5252,6 +5488,11 @@ unicorn-magic@^0.1.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
@@ -5279,6 +5520,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use-sync-external-store@1.2.2:
   version "1.2.2"
@@ -5499,6 +5748,24 @@ word-wrap@^1.2.5:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
@@ -5523,6 +5790,11 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -5533,6 +5805,24 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
@@ -5542,6 +5832,11 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+yoctocolors-cjs@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
+  integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
 zustand@^4.4.0:
   version "4.5.5"


### PR DESCRIPTION
Adds a mock mode which can be run with `yarn mock` from `workflows/frontend/dashboard`.
Mocks out queries and keycloak and mocks subscriptions as queries.
Refactors SingleWorkflowView and WorkflowRelay into live, mock, base and top level components. These components prevent the calling of hooks conditionally and should help if we want to conditionally set up subscriptions only for workflows still in progress.
The mocking can be the basis for writing tests in future for components in relay-workflows-lib.
The data in the mocks can be improved when we have better test workflows.