### PR TITLE
Improve example template

### DIFF
--- a/examples/conventional-templates/example-template.yaml
+++ b/examples/conventional-templates/example-template.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/argoproj/argo-workflows/main/api/jsonschema/schema.json
 apiVersion: argoproj.io/v1alpha1
 kind: ClusterWorkflowTemplate
 metadata:


### PR DESCRIPTION
Added a step to create a hdf5 file (may be useful if anyone creates a hdf5 viewer component)
Changed the file name name to `example-template.yaml`
Use this schema for yaml linting https://raw.githubusercontent.com/argoproj/argo-workflows/main/api/jsonschema/schema.json