### PR TITLE
feat(frontend): changed navigation link to workflow name page

### DIFF
--- a/frontend/workflows-lib/lib/components/workflow/WorkflowAccordion.tsx
+++ b/frontend/workflows-lib/lib/components/workflow/WorkflowAccordion.tsx
@@ -50,7 +50,9 @@ const WorkflowAccordion: React.FC<WorkflowProps> = ({
         <Box sx={{ display: "flex", flexGrow: 1, gap: 2 }}>
           {getWorkflowStatusIcon(workflow.status)}
           {workflowLink && (
-            <Link to={`/workflows/${visitToText(workflow.instrumentSession)}/${workflow.name}`}>
+            <Link
+              to={`/workflows/${visitToText(workflow.instrumentSession)}/${workflow.name}`}
+            >
               <OpenInNewIcon />
             </Link>
           )}


### PR DESCRIPTION
I believe the issue in AP-886 was due to useResolvedPath. I have instead defined a full path to the workflow page in the icon link.