### PR TITLE
fix(sessionspaces): disambiguate columns in sessionspaces ispyb query

### DIFF
--- a/.github/workflows/_sessionspaces_code.yaml
+++ b/.github/workflows/_sessionspaces_code.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ispyb:
-        image: ghcr.io/diamondlightsource/ispyb-database:v3.0.0
+        image: ghcr.io/diamondlightsource/ispyb-database:v4.9.0
         ports:
           - 3306:3306
         env:
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ispyb:
-        image: ghcr.io/diamondlightsource/ispyb-database:v3.0.0
+        image: ghcr.io/diamondlightsource/ispyb-database:v4.9.0
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/_sessionspaces_container.yaml
+++ b/.github/workflows/_sessionspaces_container.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ispyb:
-        image: ghcr.io/diamondlightsource/ispyb-database:v3.0.0
+        image: ghcr.io/diamondlightsource/ispyb-database:v4.9.0
         ports:
           - 3306:3306
         env:

--- a/backend/sessionspaces/.devcontainer.local/docker-compose.yml
+++ b/backend/sessionspaces/.devcontainer.local/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       LDAP_URL: ldap://127.0.0.1:1389
 
   ispyb:
-    image: ghcr.io/diamondlightsource/ispyb-database:v3.0.0
+    image: ghcr.io/diamondlightsource/ispyb-database:v4.9.0
     restart: unless-stopped
     ports:
     - "3306:3306"

--- a/backend/sessionspaces/.devcontainer/docker-compose.yml
+++ b/backend/sessionspaces/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       DATABASE_URL: mysql://root:rootpassword@ispyb/ispyb_build
 
   ispyb:
-    image: ghcr.io/diamondlightsource/ispyb-database:v3.0.0
+    image: ghcr.io/diamondlightsource/ispyb-database:v4.9.0
     restart: unless-stopped
     environment:
       MARIADB_ROOT_PASSWORD: rootpassword

--- a/backend/sessionspaces/src/permissionables/basic_info.rs
+++ b/backend/sessionspaces/src/permissionables/basic_info.rs
@@ -35,14 +35,14 @@ impl BasicInfo {
             BasicInfoRow,
             "
             SELECT
-                sessionId as id,
-                proposalId as proposal_id,
-                proposalCode as proposal_code,
-                proposalNumber as proposal_number,
-                visit_number as visit,
-                beamLineName as instrument,
-                startDate as start_date,
-                endDate as end_date
+                BLSession.sessionId AS id,
+                Proposal.proposalId AS proposal_id,
+                Proposal.proposalCode AS proposal_code,
+                Proposal.proposalNumber AS proposal_number,
+                BLSession.visit_number AS visit,
+                BLSession.beamLineName AS instrument,
+                BLSession.startDate AS start_date,
+                BLSession.endDate AS end_date
             FROM
                 BLSession
                 JOIN Proposal USING (proposalId)


### PR DESCRIPTION
sessionspaces performs the following query:

SELECT
    sessionId as id,
    proposalId as proposal_id,
    proposalCode as proposal_code,
    proposalNumber as proposal_number,
    visit_number as visit,
    beamLineName as instrument,
    startDate as start_date,
    endDate as end_date
FROM
    BLSession
    JOIN Proposal USING (proposalId)

The database schema has changed and the Proposal table now has a startDate, as well as the BLSession table. This causes the SQL query to fail with the error:

2025-10-03T18:10:06.344501Z  WARN sessionspaces: Encountered error when fetching sessions: error returned from database: 1052 (23000): Column 'startDate' in SELECT is ambiguous

and fail to receive updates from ispyb. 