### PR TITLE
fix(charts): add missing key keycloakScope to dashboard values.yaml

### DIFF
--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dashboard
 description: A dashboard for Diamond workflows
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.1.11
 dependencies:
   - name: common

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -2,6 +2,7 @@ configuration:
   keycloakUrl: https://authn.diamond.ac.uk
   keycloakRealm: master
   keycloakClient: workflows-dashboard
+  keycloakScope: "openid profile posix-uid email"
   graphUrl: https://workflows.diamond.ac.uk/graphql
   graphWsUrl: wss://workflows.diamond.ac.uk/graphql/ws
   sourceDir: "/usr/share/nginx/html"


### PR DESCRIPTION
The key was missed in the previous commit. This needs to be merged before the next release of dashboard