### PR TITLE
Fix re-submission of workflows with array parameters

### DIFF
--- a/backend/graph-proxy/src/graphql/workflows.rs
+++ b/backend/graph-proxy/src/graphql/workflows.rs
@@ -11,6 +11,7 @@ use async_graphql::{
 use aws_sdk_s3::presigning::PresigningConfig;
 use axum_extra::headers::{authorization::Bearer, Authorization};
 use chrono::{DateTime, Utc};
+use serde_json::{from_str, Value};
 use std::{collections::HashMap, ops::Deref, path::Path};
 use tracing::{debug, instrument};
 use url::Url;
@@ -92,18 +93,18 @@ impl Workflow {
     }
 
     /// The top-level workflow parameters
-    async fn parameters(&self) -> Option<HashMap<&str, Option<&str>>> {
-        let arguments = self.manifest.spec.arguments.as_ref();
+    async fn parameters(&self) -> Option<HashMap<&str, Value>> {
+        let arguments = self.manifest.spec.arguments.as_ref()?;
+        let mut param_map = HashMap::new();
 
-        if let Some(args) = arguments {
-            let params = &args.parameters;
-            let mut param_map: HashMap<&str, Option<&str>> = HashMap::new();
-            params.iter().for_each(|this_parameter| {
-                param_map.insert(&this_parameter.name, this_parameter.value.as_deref());
-            });
-            return Some(param_map);
+        for p in &arguments.parameters {
+            let value = match &p.value {
+                Some(v) => from_str(v).unwrap_or(Value::String(v.clone())),
+                None => Value::Null,
+            };
+            param_map.insert(p.name.as_str(), value);
         }
-        None
+        Some(param_map)
     }
 
     /// The name of the template used to run the workflow
@@ -1663,7 +1664,77 @@ mod tests {
             "workflow": {
                 "parameters": {
                     "memory": "10Gi",
-                    "size": "1000"
+                    "size": 1000
+                }
+            }
+        });
+        assert_eq!(resp.data.into_json().unwrap(), expected_data);
+    }
+
+    #[tokio::test]
+    async fn workflow_array_parameters() {
+        let workflow_name = "xrf-tomography-chbrh";
+        let visit = Visit {
+            proposal_code: "mg".to_string(),
+            proposal_number: 36964,
+            number: 1,
+        };
+
+        let mut server = mockito::Server::new_async().await;
+        let mut response_file_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        response_file_path.push("test-assets");
+        response_file_path.push("get-workflow-with-arrays.json");
+        let workflow_endpoint = server
+            .mock(
+                "GET",
+                &format!("/api/v1/workflows/{visit}/{workflow_name}")[..],
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_file(response_file_path)
+            .create_async()
+            .await;
+
+        let argo_server_url = Url::parse(&server.url()).unwrap();
+        let schema = root_schema_builder()
+            .data(ArgoServerUrl(argo_server_url))
+            .data(None::<Authorization<Bearer>>)
+            .finish();
+        let query = format!(
+            r#"
+            query {{
+                workflow(name: "{}", visit: {{proposalCode: "{}", proposalNumber: {}, number: {}}}) {{
+                   parameters
+                }}
+            }}
+        "#,
+            workflow_name, visit.proposal_code, visit.proposal_number, visit.number
+        );
+        let resp = schema.execute(query).await.into_result().unwrap();
+
+        workflow_endpoint.assert_async().await;
+        let expected_data = json!({
+            "workflow": {
+                "parameters": {
+                    "multiScan": [
+                        {
+                        "multiScan": {
+                            "end": 100,
+                            "excluded": [],
+                            "start": 10
+                        }
+                        }
+                    ],
+                    "outputFolder": "testing",
+                    "multiEdge": [
+                        {
+                        "edgeElement": "N",
+                        "edgeTransition": "Lb"
+                        },
+
+                    ],
+                    "normalise": true,
+                    "alignmentSection": "all",
                 }
             }
         });

--- a/backend/graph-proxy/test-assets/get-workflow-with-arrays.json
+++ b/backend/graph-proxy/test-assets/get-workflow-with-arrays.json
@@ -1,0 +1,64 @@
+{
+    "metadata": {
+        "annotations": {
+            "workflows.argoproj.io/pod-name-format": "v1"
+        },
+        "creationTimestamp": "2026-04-08T13:23:58Z",
+        "generateName": "xrf-tomography-",
+        "generation": 3,
+        "labels": {
+            "workflows.argoproj.io/cluster-workflow-template": "xrf-tomography",
+            "workflows.argoproj.io/completed": "false",
+            "workflows.argoproj.io/creator": "8c6c8d05-0dc8-49bf-b732-f4c842d71086",
+            "workflows.argoproj.io/creator-email": "james.gilbert.at.diamond.ac.uk",
+            "workflows.argoproj.io/creator-preferred-username": "gmg29649",
+            "workflows.argoproj.io/phase": "Running",
+            "workflows.diamond.ac.uk/creator-posix-uid": "1227486"
+        },
+        "name": "xrf-tomography-chbrh",
+        "namespace": "mg36964-1",
+        "resourceVersion": "1983737624",
+        "uid": "bdb252fc-75e3-40c4-893f-e0210b79f64a"
+    },
+    "spec": {
+        "arguments": {
+            "parameters": [
+                {
+                    "name": "normalise",
+                    "value": "true"
+                },
+                {
+                    "name": "alignmentSection",
+                    "value": "all"
+                },
+                {
+                    "name": "outputFolder",
+                    "value": "testing"
+                },
+                {
+                    "name": "multiEdge",
+                    "value": "[{\"edgeElement\":\"N\",\"edgeTransition\":\"Lb\"}]"
+                },
+                {
+                    "name": "multiScan",
+                    "value": "[{\"multiScan\":{\"end\":100,\"excluded\":[],\"start\":10}}]"
+                }
+            ]
+        },
+        "podGC": {
+            "deleteDelayDuration": "60s",
+            "strategy": "OnPodCompletion"
+        },
+        "podMetadata": {
+            "labels": {
+                "kueue.x-k8s.io/priority-class": "medium",
+                "kueue.x-k8s.io/queue-name": "default-queue"
+            }
+        },
+        "workflowTemplateRef": {
+            "clusterScope": true,
+            "name": "xrf-tomography"
+        }
+    },
+    "status": {}
+}

--- a/frontend/dashboard/src/mocks/responses/workflows/WorkflowsListViewQueryResponse.ts
+++ b/frontend/dashboard/src/mocks/responses/workflows/WorkflowsListViewQueryResponse.ts
@@ -912,9 +912,9 @@ export const workflowsListViewQueryResponse = {
         },
         templateRef: "sin-simulate-artifact",
         parameters: {
-          stop: "10",
-          step: "1",
-          start: "0",
+          stop: 10,
+          step: 1,
+          start: 0,
         },
         creator: {
           creatorId: "abc12345",

--- a/frontend/dashboard/src/mocks/responses/workflows/sin-simulate-artifact-first.json
+++ b/frontend/dashboard/src/mocks/responses/workflows/sin-simulate-artifact-first.json
@@ -7,9 +7,9 @@
   },
   "templateRef": "sin-simulate-artifact",
   "parameters": {
-    "stop": "10",
-    "step": "1",
-    "start": "0"
+    "stop": 10,
+    "step": 1,
+    "start": 0
   },
   "status": {
     "__typename": "WorkflowSucceededStatus",

--- a/frontend/workflows-lib/tests/components/JsonFormsScanRangeRenderer.test.tsx
+++ b/frontend/workflows-lib/tests/components/JsonFormsScanRangeRenderer.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { JsonForms } from "@jsonforms/react";
+import { rendererSet } from "../../lib/utils/renderers";
+import userEvent from "@testing-library/user-event";
+
+const matchingUISchema = {
+  type: "Control",
+  scope: "#/properties/multiScan",
+  options: {
+    elementLabelProp: "scanRange",
+    detail: {
+      type: "VerticalLayout",
+      elements: [
+        {
+          type: "Control",
+          scope: "#/properties/multiScan/items",
+          options: {
+            useScanRangeControl: true,
+          },
+        },
+      ],
+    },
+  },
+};
+
+const schema = {
+  type: "object",
+  properties: {
+    multiScan: {
+      title: "Scans",
+      type: "array",
+      items: {
+        type: "object",
+      },
+    },
+  },
+};
+
+const nonMatchingUISchema = { ...matchingUISchema, options: {} };
+
+describe("ScanRangeInputRenderer", () => {
+  const user = userEvent.setup();
+  const handleChange = vi.fn();
+  const mockData = {
+    multiScan: [
+      { multiScan: { start: "1421", end: "3204", excluded: [3200] } },
+    ],
+  };
+
+  it("renders for matching schema", async () => {
+    render(
+      <JsonForms
+        schema={schema}
+        uischema={matchingUISchema}
+        data={mockData}
+        renderers={rendererSet}
+        onChange={handleChange}
+      />,
+    );
+    expect(screen.getByLabelText("Index")).toHaveTextContent("1");
+    await user.click(screen.getByRole("button", { name: "Index" }));
+    expect(screen.getByRole("spinbutton", { name: "Start" })).toHaveValue(1421);
+    expect(screen.getByRole("spinbutton", { name: "End" })).toHaveValue(3204);
+    expect(screen.getByRole("textbox", { name: "Excluded" })).toHaveValue(
+      "3200",
+    );
+  });
+
+  it("Does not render for non-matching schema", () => {
+    render(
+      <JsonForms
+        schema={schema}
+        uischema={nonMatchingUISchema}
+        data={mockData}
+        renderers={rendererSet}
+        onChange={handleChange}
+      />,
+    );
+    expect(screen.queryByLabelText("Index")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
[AP-1072](https://jira.diamond.ac.uk/browse/AP-1072)
Tweaks graph-proxy to treat workflow parameters as `Value`s instead of strings, allowing arrays to be returned by queries