### PR TITLE
chore(deps): bump all storybook packages to 10.3.5

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,5 +13,6 @@ dist-ssr
 *.local
 
 *storybook.log
+storybook-static
 
 *.tsbuildinfo

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -7,7 +7,7 @@ import vitest from "@vitest/eslint-plugin";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig(
-  { ignores: ["**/dist"] },
+  { ignores: ["**/dist", "**/storybook-static"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked],
     files: ["**/*.{ts,tsx}"],

--- a/frontend/workflows-lib/.storybook/main.ts
+++ b/frontend/workflows-lib/.storybook/main.ts
@@ -1,28 +1,17 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
-import { join, dirname } from "path";
-
-/**
- * This function is used to resolve the absolute path of a package.
- * It is needed in projects that use Yarn PnP or are set up within a monorepo.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getAbsolutePath(value: string): any {
-  return dirname(require.resolve(join(value, "package.json")));
-}
 const config: StorybookConfig = {
   stories: [
     "../stories/**/*.mdx",
     "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
   addons: [
-    getAbsolutePath("@storybook/addon-links"),
-    getAbsolutePath("@chromatic-com/storybook"),
-    getAbsolutePath("@storybook/addon-docs"),
+    "@storybook/addon-links",
+    "@chromatic-com/storybook",
+    "@storybook/addon-docs",
   ],
   framework: {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    name: getAbsolutePath("@storybook/react-vite"),
+    name: "@storybook/react-vite",
     options: {},
   },
 };

--- a/frontend/workflows-lib/.storybook/manager-head.html
+++ b/frontend/workflows-lib/.storybook/manager-head.html
@@ -1,0 +1,11 @@
+<!-- This is to circumvent a view window bug in Firefox v140
+    see https://github.com/storybookjs/storybook/discussions/33795 -->
+<style>
+  @-moz-document url-prefix() {
+    iframe[title="storybook-preview-iframe"] {
+      position: static !important;
+      width: 100% !important;
+      height: 100vh !important;
+    }
+  }
+</style>

--- a/frontend/workflows-lib/package.json
+++ b/frontend/workflows-lib/package.json
@@ -33,12 +33,13 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.2",
     "@storybook/addon-links": "^10.3.5",
-    "@storybook/react-vite": "^9.1.15",
+    "@storybook/builder-vite": "^10.3.5",
+    "@storybook/react-vite": "^10.3.5",
     "@types/jest": "^30.0.0",
     "@types/react-resizable": "^3.0.8",
     "react-resizable": "^3.0.5",
-    "storybook": "^9.1.19",
-    "@storybook/addon-docs": "^10.0.6"
+    "storybook": "^10.3.5",
+    "@storybook/addon-docs": "^10.3.5"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Dependabot's #1053 won't work; this will match all storybook dependencies to `10.3.5` and implement the changes required to comply with v10 breaking changes. 
Firefox v140 (which is what DLS uses) has a bug that restricts the size of the view window in the updated storybook, but [there is an established workaround for this](https://github.com/storybookjs/storybook/discussions/33795), which I have included.