### PR TITLE
chore(charts): staging accepts identity-test tokens

### DIFF
--- a/charts/workflows-cluster/Chart.yaml
+++ b/charts/workflows-cluster/Chart.yaml
@@ -3,7 +3,7 @@ name: workflows-cluster
 description: A virtual cluster for Data Analysis workflows
 type: application
 
-version: 0.13.0
+version: 0.13.1
 dependencies:
   - name: common
     version: 2.23.0

--- a/charts/workflows-cluster/staging-values.yaml
+++ b/charts/workflows-cluster/staging-values.yaml
@@ -142,6 +142,53 @@ authenticationConfiguration:
       - expression: "user.groups.all(group, !group.startsWith('system:'))"
         message: 'groups cannot use reserved system: prefix'
     - issuer:
+        url: https://identity-test.diamond.ac.uk/realms/dls
+        audiences:
+          - workflows-cluster-staging
+          - graph
+        audienceMatchPolicy: MatchAny
+      claimMappings:
+        username:
+          expression: >
+            claims.?fedid.hasValue()
+            ? ('oidc:' + claims.fedid)
+            : ('oidc:' + claims.iss + '/' + claims.client_id)
+        uid:
+          expression: "claims.?fedid.orValue(claims.sub)"
+        groups:
+          claim: groups
+          prefix: "oidc:"
+        extra:
+        - key: 'workflows.diamond.ac.uk/posixuid'
+          valueExpression: "string(claims.?posix_uid.orValue(36055))" # use k8s-workflows uid
+        - key: 'workflows.diamond.ac.uk/is-service-account'
+          valueExpression: "claims.?fedid.hasValue() ? '' : 'true'"
+      claimValidationRules:
+      - expression: >
+          claims.?fedid.hasValue()
+          ||
+          claims.?client_id.hasValue()
+        message: "Invalid access token (no fedid or client_id). See: https://diamondlightsource.github.io/workflows/docs/how-tos/authentication/"
+      - expression: >
+          claims.?fedid.hasValue()
+          ||
+          claims.?preferred_username.orValue('').startsWith('service-account-')
+        message: "Invalid access token (service-account tokens must use service-account-* preferred_username). See: https://diamondlightsource.github.io/workflows/docs/how-tos/authentication/"
+      - expression: >
+          claims.?fedid.hasValue()
+          ||
+          (
+            claims.?client_id.hasValue()
+            &&
+            ['k6Operator'].exists(allowed, allowed == claims.client_id)
+          )
+        message: "Invalid access token (service account not on allowed-list). See: https://diamondlightsource.github.io/workflows/docs/how-tos/authentication/"
+      userValidationRules:
+      - expression: "!user.username.startsWith('system:')"
+        message: 'username cannot use reserved system: prefix'
+      - expression: "user.groups.all(group, !group.startsWith('system:'))"
+        message: 'groups cannot use reserved system: prefix'
+    - issuer:
         url: https://authn.diamond.ac.uk/realms/master
         audiences:
           - workflows-cluster-staging


### PR DESCRIPTION
This initiates the migration from identity-dev to identity-test as requested by Keycloak team. The config duplication will be eliminated in a future PR when identity-dev is removed.