### PR TITLE
fix(charts): remove cleanup to stop continuous ruruns of load tests

### DIFF
--- a/charts/k6-operator/Chart.yaml
+++ b/charts/k6-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k6-op
 description: k6 chart for k8s
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.16.0"
 dependencies:
   - name: k6-operator

--- a/charts/k6-operator/templates/k6-testrun.yaml
+++ b/charts/k6-operator/templates/k6-testrun.yaml
@@ -6,7 +6,6 @@ metadata:
   name: k6-ping-graph
   namespace: {{ .Release.Namespace}}
 spec:
-  cleanup: 'post'
   parallelism: 4
   script:
     configMap:

--- a/charts/k6-operator/templates/k6-ws-subscription-testrun.yaml
+++ b/charts/k6-operator/templates/k6-ws-subscription-testrun.yaml
@@ -6,7 +6,6 @@ metadata:
   name: k6-ws-subscription
   namespace: {{ .Release.Namespace}}
 spec:
-  cleanup: 'post'
   parallelism: 1
   script:
     configMap:


### PR DESCRIPTION
`cleanup: 'post'` successfully removes CRDs and `TestRun` resources. However it seems like argoCD sees the removal of the CRDs, and considers k6 "out of sync". Therefore on every sync, it recreates the CRDs and `TestRun` resources and reruns the load tests. This leads to load tests being continuously run (every ~10-15 mins). Does not affect synthetic probe.