### PR TITLE
Standardise CPU and Memory Resources for Argo Workflows

### DIFF
--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: apps
 description: An argocd app to deploy apps inside the virtual cluster
 type: application
-version: 0.5.4
+version: 0.5.5

--- a/charts/apps/templates/mpi-operator-application.yaml
+++ b/charts/apps/templates/mpi-operator-application.yaml
@@ -15,6 +15,23 @@ spec:
     repoURL: https://github.com/kubeflow/mpi-operator.git
     path: deploy/v2beta1
     targetRevision: {{ .Values.kueue.targetRevision }}
+
+    kustomize:
+      patches:
+        - target:
+            kind: Deployment
+            name: mpi-operator
+          patch: |
+            - op: add
+              path: /spec/template/spec/containers/0/resources
+              value:
+                limits:
+                  cpu: 1000m
+                  memory: 4Gi
+                requests:
+                  cpu: 250m
+                  memory: 2.5Gi
+
   ignoreDifferences:
     - group: rbac.authorization.k8s.io
       kind: ClusterRole

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -3,7 +3,7 @@ name: events
 description: Data Analysis event triggering
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: argo-events

--- a/charts/events/dev-values.yaml
+++ b/charts/events/dev-values.yaml
@@ -2,11 +2,11 @@ argo-events:
   controller:
     resources:
       limits:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 1000m
+        memory: 4Gi
       requests:
-        cpu: 250m
-        memory: 256Mi
+        cpu: 500m
+        memory: 2Gi
   webhook:
     resources:
       limits:

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: workflows
 description: Data Analysis workflow orchestration
 type: application
-version: 0.13.44
+version: 0.13.45
 dependencies:
   - name: argo-workflows
     repository: https://argoproj.github.io/argo-helm

--- a/charts/workflows/rendered.yaml
+++ b/charts/workflows/rendered.yaml
@@ -1,0 +1,5726 @@
+---
+# Source: workflows/charts/postgresql-ha/templates/pgpool/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: workflows-postgresql-ha-pgpool
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: pgpool
+    role: data
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: pgpool
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432
+        - port: 9187
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: workflows-postgresql-ha-postgresql
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+    role: data
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: postgresql
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432
+        - port: 9187
+---
+# Source: workflows/charts/oauth2-proxy/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: workflows
+  minAvailable: 1
+---
+# Source: workflows/charts/postgresql-ha/templates/pgpool/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: workflows-postgresql-ha-pgpool
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 4.5.4
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: pgpool
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: pgpool
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: workflows-postgresql-ha-postgresql
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: postgresql
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/witness-pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: workflows-postgresql-ha-postgresql-witness 
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+    role: witness
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: postgresql
+      role: witness
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflows-argo-workflows-workflow-controller
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflows-argo-workflows-server
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+---
+# Source: workflows/charts/oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+automountServiceAccountToken: true
+---
+# Source: workflows/charts/postgresql-ha/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflows-postgresql-ha
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+automountServiceAccountToken: false
+---
+# Source: workflows/templates/synchronize-artifact-s3-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: artifact-s3-cloner
+  namespace: workflows
+---
+# Source: workflows/templates/workflows-user-service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflows-user
+  namespace: gmm14360
+  annotations:
+    workflows.argoproj.io/rbac-rule: "true"
+---
+# Source: workflows/charts/oauth2-proxy/templates/secret-alpha.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy-alpha
+  namespace: gmm14360
+data:
+  oauth2_proxy.yml: "LS0tCnNlcnZlcjoKICBCaW5kQWRkcmVzczogJzAuMC4wLjA6NDE4MCcKbWV0cmljc1NlcnZlcjoKICBCaW5kQWRkcmVzczogJzAuMC4wLjA6NDQxODAnCmluamVjdFJlcXVlc3RIZWFkZXJzOgotIG5hbWU6IEF1dGhvcml6YXRpb24KICBwcmVzZXJ2ZVJlcXVlc3RWYWx1ZTogdHJ1ZQogIHZhbHVlczoKICAtIGNsYWltOiBhY2Nlc3NfdG9rZW4KICAgIHByZWZpeDogJ0JlYXJlciAnCmluamVjdFJlc3BvbnNlSGVhZGVyczoKLSBuYW1lOiBJZGVudGl0eQogIHZhbHVlczoKICAtIGNsYWltOiBpZF90b2tlbgpwcm92aWRlcnM6Ci0gY2xpZW50SWQ6IHdvcmtmbG93cy1hcmdvLXNlcnZlcgogIGNsaWVudFNlY3JldEZpbGU6IC9ldGMvYWxwaGEvc2VjcmV0CiAgaWQ6IGF1dGhuCiAgb2lkY0NvbmZpZzoKICAgIGF1ZGllbmNlQ2xhaW1zOgogICAgLSBhdWQKICAgIGVtYWlsQ2xhaW06IGVtYWlsCiAgICBleHRyYUF1ZGllbmNlczoKICAgIC0gd29ya2Zsb3dzLWNsdXN0ZXItc3RhZ2luZwogICAgLSBncmFwaAogICAgaW5zZWN1cmVBbGxvd1VudmVyaWZpZWRFbWFpbDogdHJ1ZQogICAgaXNzdWVyVVJMOiBodHRwczovL2lkZW50aXR5LmRpYW1vbmQuYWMudWsvcmVhbG1zL2RscwogICAgdXNlcklEQ2xhaW06IGZlZGlkCiAgcHJvdmlkZXI6IG9pZGMKICBzY29wZTogb3BlbmlkIHBvc2l4LXVpZCBwcm9maWxlIGVtYWlsIGZlZGlkCnVwc3RyZWFtQ29uZmlnOgogIHVwc3RyZWFtczoKICAgIC0gaWQ6IGFyZ28td29ya2Zsb3dzLXNlcnZlcgogICAgICBwYXRoOiAvCiAgICAgIHVyaTogaHR0cDovL3dvcmtmbG93cy1hcmdvLXdvcmtmbG93cy1zZXJ2ZXI6Mjc0Ng=="
+---
+# Source: workflows/charts/oauth2-proxy/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+type: Opaque
+data:
+  cookie-secret: "WFhYWFhYWFhYWFhYWFhYWA=="
+  client-secret: "WFhYWFhYWFg="
+  client-id: "WFhYWFhYWA=="
+---
+# Source: workflows/templates/pgpool-passwords-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgpool-passwords
+data:
+  admin-password: SHJHVVV2aFQ1YW0za2pUNGVxRkxGamRO
+---
+# Source: workflows/templates/workflows-user-service-account.yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: workflows-user.service-account-token
+  namespace: gmm14360
+  annotations:
+    kubernetes.io/service-account.name: workflows-user
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflows-argo-workflows-workflow-controller-configmap
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-cm
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+data:
+  config: |
+    artifactRepository:
+      archiveLogs: true
+      s3:
+        accessKeySecret:
+          key: access-key
+          name: artifact-s3
+        secretKeySecret:
+          key: secret-key
+          name: artifact-s3
+        bucket: k8s-workflows-test
+        endpoint: sci-nas-s3.diamond.ac.uk
+        insecure: 
+        region: unsupported
+    metricsConfig:
+      enabled: true
+      path: /metrics
+      port: 9090
+      ignoreErrors: false
+      secure: false
+    persistence:
+      archive: true
+      postgresql:
+        database: argo_workflows
+        host: workflows-postgresql-ha-pgpool
+        passwordSecret:
+          key: password
+          name: postgres-argo-workflows-password
+        port: 5432
+        tableName: workflows
+        userNameSecret:
+          key: username
+          name: postgres-argo-workflows-password
+    workflowDefaults:
+      spec:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                - key: nodegroup
+                  operator: In
+                  values:
+                  - workflows
+              weight: 100
+        podSpecPatch: |
+          containers:
+            - name: main
+              resources:
+                requests:
+                  memory: "2Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "4Gi"
+                  cpu: "1000m"
+        serviceAccountName: argo-workflow
+        tolerations:
+        - effect: NoSchedule
+          key: nodegroup
+          operator: Equal
+          value: workflows
+        - effect: PreferNoSchedule
+          key: nodetype
+          operator: Equal
+          value: cs05r_gpfs
+        ttlStrategy:
+          secondsAfterCompletion: 300
+          secondsAfterFailure: 60
+    nodeEvents:
+      enabled: true
+    workflowEvents:
+      enabled: true
+---
+# Source: workflows/charts/oauth2-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+data:
+  oauth2_proxy.cfg: "email_domains = [\n  \"*\"\n]\n\nskip_auth_routes = [\n  \"OPTIONS=^/$\",\n  \"GET=^/api/\",\n  \"DELETE=^/api/\",\n  \"PUT=^/api/\",\n  \"POST=^/api/\",\n  \"GET=^/artifact-files/\",\n  \"GET=^/artifacts-by-uid/\",\n  \"GET=^/artifacts/\",\n  \"GET=^/input-artifacts-by-uid/\",\n  \"GET=^/input-artifacts/\",\n  \"GET=^/assets/\"\n]\n\nskip_provider_button = true"
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflows-postgresql-ha-postgresql-hooks-scripts
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+data:
+  pre-stop.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    # Debug section
+    exec 3>&1
+    exec 4>&2
+
+    # Process input parameters
+    MIN_DELAY_AFTER_PG_STOP_SECONDS=$1
+
+    # Load Libraries
+    . /opt/bitnami/scripts/liblog.sh
+    . /opt/bitnami/scripts/libpostgresql.sh
+    . /opt/bitnami/scripts/librepmgr.sh
+
+    # Load PostgreSQL & repmgr environment variables
+    . /opt/bitnami/scripts/postgresql-env.sh
+
+    # Auxiliary functions
+    is_new_primary_ready() {
+        return_value=1
+        currenty_primary_node="$(repmgr_get_primary_node)"
+        currenty_primary_host="$(echo $currenty_primary_node | awk '{print $1}')"
+
+        info "$currenty_primary_host != $REPMGR_NODE_NETWORK_NAME"
+        if [[ $(echo $currenty_primary_node | wc -w) -eq 2 ]] && [[ "$currenty_primary_host" != "$REPMGR_NODE_NETWORK_NAME" ]]; then
+            info "New primary detected, leaving the cluster..."
+            return_value=0
+        else
+            info "Waiting for a new primary to be available..."
+        fi
+        return $return_value
+    }
+
+    export MODULE="pre-stop-hook"
+
+    if [[ "${BITNAMI_DEBUG}" == "true" ]]; then
+        info "Bash debug is on"
+    else
+        info "Bash debug is off"
+        exec 1>/dev/null
+        exec 2>/dev/null
+    fi
+
+    postgresql_enable_nss_wrapper
+
+    # Prepare env vars for managing roles
+    readarray -t primary_node < <(repmgr_get_upstream_node)
+    primary_host="${primary_node[0]}"
+
+    # Stop postgresql for graceful exit.
+    PG_STOP_TIME=$EPOCHSECONDS
+    postgresql_stop
+
+    if [[ -z "$primary_host" ]] || [[ "$primary_host" == "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        info "Primary node need to wait for a new primary node before leaving the cluster"
+        retry_while is_new_primary_ready 10 5
+    else
+        info "Standby node doesn't need to wait for a new primary switchover. Leaving the cluster"
+    fi
+
+    # Make sure pre-stop hook waits at least 25 seconds after stop of PG to make sure PGPOOL detects node is down.
+    # default terminationGracePeriodSeconds=30 seconds
+    PG_STOP_DURATION=$(($EPOCHSECONDS - $PG_STOP_TIME))
+    if (( $PG_STOP_DURATION < $MIN_DELAY_AFTER_PG_STOP_SECONDS )); then
+        WAIT_TO_PG_POOL_TIME=$(($MIN_DELAY_AFTER_PG_STOP_SECONDS - $PG_STOP_DURATION)) 
+        info "PG stopped including primary switchover in $PG_STOP_DURATION. Waiting additional $WAIT_TO_PG_POOL_TIME seconds for PG pool"
+        sleep $WAIT_TO_PG_POOL_TIME
+    fi
+
+  readiness-probe.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    # Debug section
+    exec 3>&1
+    exec 4>&2
+
+    # Load Libraries
+    . /opt/bitnami/scripts/liblog.sh
+    . /opt/bitnami/scripts/libpostgresql.sh
+
+    # Load PostgreSQL & repmgr environment variables
+    . /opt/bitnami/scripts/postgresql-env.sh
+
+    # Process input parameters
+    MIN_DELAY_AFTER_POD_READY_FIRST_TIME=$1
+    TMP_FIRST_READY_FILE_TS="/tmp/ts-first-ready.mark"
+    TMP_DELAY_APPLIED_FILE="/tmp/delay-applied.mark"
+
+    DB_CHECK_RESULT=$(echo "SELECT 1" | postgresql_execute_print_output "$POSTGRESQL_DATABASE" "$POSTGRESQL_USERNAME" "$POSTGRESQL_PASSWORD" "-h 127.0.0.1 -tA" || echo "command failed")
+    if [[ "$DB_CHECK_RESULT" == "1" ]]; then
+      if [[ ! -f "$TMP_DELAY_APPLIED_FILE" ]]; then
+        # DB up, but initial readiness delay not applied
+        if [[ -f "$TMP_FIRST_READY_FILE_TS" ]]; then
+          # calculate delay from the first readiness success
+          FIRST_READY_TS=$(cat $TMP_FIRST_READY_FILE_TS)
+          CURRENT_DELAY_SECONDS=$(($EPOCHSECONDS - $FIRST_READY_TS))
+          if (( $CURRENT_DELAY_SECONDS > $MIN_DELAY_AFTER_POD_READY_FIRST_TIME )); then
+            # minimal delay of the first readiness state passed - report success and mark delay as applied
+            touch "$TMP_DELAY_APPLIED_FILE"
+          else
+            # minimal delay of the first readiness state not reached yet - report failure
+            exit 1
+          fi
+        else
+          # first ever readiness test success - store timestamp and report failure
+          echo $EPOCHSECONDS > $TMP_FIRST_READY_FILE_TS
+          exit 1
+        fi
+      fi
+    else
+      # DB test failed - report failure
+      exit 1
+    fi
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_clusterworkflowtemplates.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterworkflowtemplates.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: ClusterWorkflowTemplate
+    listKind: ClusterWorkflowTemplateList
+    plural: clusterworkflowtemplates
+    shortNames:
+    - clusterwftmpl
+    - cwft
+    singular: clusterworkflowtemplate
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_cronworkflows.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cronworkflows.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: CronWorkflow
+    listKind: CronWorkflowList
+    plural: cronworkflows
+    shortNames:
+    - cwf
+    - cronwf
+    singular: cronworkflow
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_workflowartifactgctasks.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowartifactgctasks.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowArtifactGCTask
+    listKind: WorkflowArtifactGCTaskList
+    plural: workflowartifactgctasks
+    shortNames:
+    - wfat
+    singular: workflowartifactgctask
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              artifactsByNode:
+                additionalProperties:
+                  properties:
+                    archiveLocation:
+                      properties:
+                        archiveLogs:
+                          type: boolean
+                        artifactory:
+                          properties:
+                            passwordSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            url:
+                              type: string
+                            usernameSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - url
+                          type: object
+                        azure:
+                          properties:
+                            accountKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            blob:
+                              type: string
+                            container:
+                              type: string
+                            endpoint:
+                              type: string
+                            useSDKCreds:
+                              type: boolean
+                          required:
+                          - blob
+                          - container
+                          - endpoint
+                          type: object
+                        gcs:
+                          properties:
+                            bucket:
+                              type: string
+                            key:
+                              type: string
+                            serviceAccountKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - key
+                          type: object
+                        git:
+                          properties:
+                            branch:
+                              type: string
+                            depth:
+                              format: int64
+                              type: integer
+                            disableSubmodules:
+                              type: boolean
+                            fetch:
+                              items:
+                                type: string
+                              type: array
+                            insecureIgnoreHostKey:
+                              type: boolean
+                            insecureSkipTLS:
+                              type: boolean
+                            passwordSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            repo:
+                              type: string
+                            revision:
+                              type: string
+                            singleBranch:
+                              type: boolean
+                            sshPrivateKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            usernameSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - repo
+                          type: object
+                        hdfs:
+                          properties:
+                            addresses:
+                              items:
+                                type: string
+                              type: array
+                            dataTransferProtection:
+                              type: string
+                            force:
+                              type: boolean
+                            hdfsUser:
+                              type: string
+                            krbCCacheSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            krbConfigConfigMap:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            krbKeytabSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            krbRealm:
+                              type: string
+                            krbServicePrincipalName:
+                              type: string
+                            krbUsername:
+                              type: string
+                            path:
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        http:
+                          properties:
+                            auth:
+                              properties:
+                                basicAuth:
+                                  properties:
+                                    passwordSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    usernameSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                clientCert:
+                                  properties:
+                                    clientCertSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    clientKeySecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                oauth2:
+                                  properties:
+                                    clientIDSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    clientSecretSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    endpointParams:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      type: array
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenURLSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        oss:
+                          properties:
+                            accessKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            bucket:
+                              type: string
+                            createBucketIfNotPresent:
+                              type: boolean
+                            endpoint:
+                              type: string
+                            key:
+                              type: string
+                            lifecycleRule:
+                              properties:
+                                markDeletionAfterDays:
+                                  format: int32
+                                  type: integer
+                                markInfrequentAccessAfterDays:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            secretKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            securityToken:
+                              type: string
+                            useSDKCreds:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        raw:
+                          properties:
+                            data:
+                              type: string
+                          required:
+                          - data
+                          type: object
+                        s3:
+                          properties:
+                            accessKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            bucket:
+                              type: string
+                            caSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            createBucketIfNotPresent:
+                              properties:
+                                objectLocking:
+                                  type: boolean
+                              type: object
+                            encryptionOptions:
+                              properties:
+                                enableEncryption:
+                                  type: boolean
+                                kmsEncryptionContext:
+                                  type: string
+                                kmsKeyId:
+                                  type: string
+                                serverSideCustomerKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            endpoint:
+                              type: string
+                            insecure:
+                              type: boolean
+                            key:
+                              type: string
+                            region:
+                              type: string
+                            roleARN:
+                              type: string
+                            secretKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sessionTokenSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            useSDKCreds:
+                              type: boolean
+                          type: object
+                      type: object
+                    artifacts:
+                      additionalProperties:
+                        properties:
+                          archive:
+                            properties:
+                              none:
+                                type: object
+                              tar:
+                                properties:
+                                  compressionLevel:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              zip:
+                                type: object
+                            type: object
+                          archiveLogs:
+                            type: boolean
+                          artifactGC:
+                            properties:
+                              podMetadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              serviceAccountName:
+                                type: string
+                              strategy:
+                                enum:
+                                - ""
+                                - OnWorkflowCompletion
+                                - OnWorkflowDeletion
+                                - Never
+                                type: string
+                            type: object
+                          artifactory:
+                            properties:
+                              passwordSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              url:
+                                type: string
+                              usernameSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - url
+                            type: object
+                          azure:
+                            properties:
+                              accountKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              blob:
+                                type: string
+                              container:
+                                type: string
+                              endpoint:
+                                type: string
+                              useSDKCreds:
+                                type: boolean
+                            required:
+                            - blob
+                            - container
+                            - endpoint
+                            type: object
+                          deleted:
+                            type: boolean
+                          from:
+                            type: string
+                          fromExpression:
+                            type: string
+                          gcs:
+                            properties:
+                              bucket:
+                                type: string
+                              key:
+                                type: string
+                              serviceAccountKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - key
+                            type: object
+                          git:
+                            properties:
+                              branch:
+                                type: string
+                              depth:
+                                format: int64
+                                type: integer
+                              disableSubmodules:
+                                type: boolean
+                              fetch:
+                                items:
+                                  type: string
+                                type: array
+                              insecureIgnoreHostKey:
+                                type: boolean
+                              insecureSkipTLS:
+                                type: boolean
+                              passwordSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              repo:
+                                type: string
+                              revision:
+                                type: string
+                              singleBranch:
+                                type: boolean
+                              sshPrivateKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              usernameSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - repo
+                            type: object
+                          globalName:
+                            type: string
+                          hdfs:
+                            properties:
+                              addresses:
+                                items:
+                                  type: string
+                                type: array
+                              dataTransferProtection:
+                                type: string
+                              force:
+                                type: boolean
+                              hdfsUser:
+                                type: string
+                              krbCCacheSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              krbConfigConfigMap:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              krbKeytabSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              krbRealm:
+                                type: string
+                              krbServicePrincipalName:
+                                type: string
+                              krbUsername:
+                                type: string
+                              path:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          http:
+                            properties:
+                              auth:
+                                properties:
+                                  basicAuth:
+                                    properties:
+                                      passwordSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      usernameSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  clientCert:
+                                    properties:
+                                      clientCertSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      clientKeySecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  oauth2:
+                                    properties:
+                                      clientIDSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      clientSecretSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      endpointParams:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - key
+                                          type: object
+                                        type: array
+                                      scopes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      tokenURLSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                type: object
+                              headers:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              url:
+                                type: string
+                            required:
+                            - url
+                            type: object
+                          mode:
+                            format: int32
+                            type: integer
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                          oss:
+                            properties:
+                              accessKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              bucket:
+                                type: string
+                              createBucketIfNotPresent:
+                                type: boolean
+                              endpoint:
+                                type: string
+                              key:
+                                type: string
+                              lifecycleRule:
+                                properties:
+                                  markDeletionAfterDays:
+                                    format: int32
+                                    type: integer
+                                  markInfrequentAccessAfterDays:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              secretKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              securityToken:
+                                type: string
+                              useSDKCreds:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          path:
+                            type: string
+                          raw:
+                            properties:
+                              data:
+                                type: string
+                            required:
+                            - data
+                            type: object
+                          recurseMode:
+                            type: boolean
+                          s3:
+                            properties:
+                              accessKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              bucket:
+                                type: string
+                              caSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              createBucketIfNotPresent:
+                                properties:
+                                  objectLocking:
+                                    type: boolean
+                                type: object
+                              encryptionOptions:
+                                properties:
+                                  enableEncryption:
+                                    type: boolean
+                                  kmsEncryptionContext:
+                                    type: string
+                                  kmsKeyId:
+                                    type: string
+                                  serverSideCustomerKeySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              endpoint:
+                                type: string
+                              insecure:
+                                type: boolean
+                              key:
+                                type: string
+                              region:
+                                type: string
+                              roleARN:
+                                type: string
+                              secretKeySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sessionTokenSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              useSDKCreds:
+                                type: boolean
+                            type: object
+                          subPath:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: object
+                  type: object
+                type: object
+            type: object
+          status:
+            properties:
+              artifactResultsByNode:
+                additionalProperties:
+                  properties:
+                    artifactResults:
+                      additionalProperties:
+                        properties:
+                          error:
+                            type: string
+                          name:
+                            type: string
+                          success:
+                            type: boolean
+                        required:
+                        - name
+                        type: object
+                      type: object
+                  type: object
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_workfloweventbindings.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workfloweventbindings.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowEventBinding
+    listKind: WorkflowEventBindingList
+    plural: workfloweventbindings
+    shortNames:
+    - wfeb
+    singular: workfloweventbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              event:
+                properties:
+                  selector:
+                    type: string
+                required:
+                - selector
+                type: object
+              submit:
+                properties:
+                  arguments:
+                    properties:
+                      artifacts:
+                        items:
+                          properties:
+                            archive:
+                              properties:
+                                none:
+                                  type: object
+                                tar:
+                                  properties:
+                                    compressionLevel:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                zip:
+                                  type: object
+                              type: object
+                            archiveLogs:
+                              type: boolean
+                            artifactGC:
+                              properties:
+                                podMetadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                serviceAccountName:
+                                  type: string
+                                strategy:
+                                  enum:
+                                  - ""
+                                  - OnWorkflowCompletion
+                                  - OnWorkflowDeletion
+                                  - Never
+                                  type: string
+                              type: object
+                            artifactory:
+                              properties:
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                url:
+                                  type: string
+                                usernameSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - url
+                              type: object
+                            azure:
+                              properties:
+                                accountKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                blob:
+                                  type: string
+                                container:
+                                  type: string
+                                endpoint:
+                                  type: string
+                                useSDKCreds:
+                                  type: boolean
+                              required:
+                              - blob
+                              - container
+                              - endpoint
+                              type: object
+                            deleted:
+                              type: boolean
+                            from:
+                              type: string
+                            fromExpression:
+                              type: string
+                            gcs:
+                              properties:
+                                bucket:
+                                  type: string
+                                key:
+                                  type: string
+                                serviceAccountKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - key
+                              type: object
+                            git:
+                              properties:
+                                branch:
+                                  type: string
+                                depth:
+                                  format: int64
+                                  type: integer
+                                disableSubmodules:
+                                  type: boolean
+                                fetch:
+                                  items:
+                                    type: string
+                                  type: array
+                                insecureIgnoreHostKey:
+                                  type: boolean
+                                insecureSkipTLS:
+                                  type: boolean
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                repo:
+                                  type: string
+                                revision:
+                                  type: string
+                                singleBranch:
+                                  type: boolean
+                                sshPrivateKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                usernameSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - repo
+                              type: object
+                            globalName:
+                              type: string
+                            hdfs:
+                              properties:
+                                addresses:
+                                  items:
+                                    type: string
+                                  type: array
+                                dataTransferProtection:
+                                  type: string
+                                force:
+                                  type: boolean
+                                hdfsUser:
+                                  type: string
+                                krbCCacheSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                krbConfigConfigMap:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                krbKeytabSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                krbRealm:
+                                  type: string
+                                krbServicePrincipalName:
+                                  type: string
+                                krbUsername:
+                                  type: string
+                                path:
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            http:
+                              properties:
+                                auth:
+                                  properties:
+                                    basicAuth:
+                                      properties:
+                                        passwordSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        usernameSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    clientCert:
+                                      properties:
+                                        clientCertSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        clientKeySecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    oauth2:
+                                      properties:
+                                        clientIDSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        clientSecretSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        endpointParams:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - key
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        tokenURLSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                                headers:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                url:
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                            mode:
+                              format: int32
+                              type: integer
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                            oss:
+                              properties:
+                                accessKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                bucket:
+                                  type: string
+                                createBucketIfNotPresent:
+                                  type: boolean
+                                endpoint:
+                                  type: string
+                                key:
+                                  type: string
+                                lifecycleRule:
+                                  properties:
+                                    markDeletionAfterDays:
+                                      format: int32
+                                      type: integer
+                                    markInfrequentAccessAfterDays:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                secretKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                securityToken:
+                                  type: string
+                                useSDKCreds:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            path:
+                              type: string
+                            raw:
+                              properties:
+                                data:
+                                  type: string
+                              required:
+                              - data
+                              type: object
+                            recurseMode:
+                              type: boolean
+                            s3:
+                              properties:
+                                accessKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                bucket:
+                                  type: string
+                                caSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                createBucketIfNotPresent:
+                                  properties:
+                                    objectLocking:
+                                      type: boolean
+                                  type: object
+                                encryptionOptions:
+                                  properties:
+                                    enableEncryption:
+                                      type: boolean
+                                    kmsEncryptionContext:
+                                      type: string
+                                    kmsKeyId:
+                                      type: string
+                                    serverSideCustomerKeySecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                endpoint:
+                                  type: string
+                                insecure:
+                                  type: boolean
+                                key:
+                                  type: string
+                                region:
+                                  type: string
+                                roleARN:
+                                  type: string
+                                secretKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sessionTokenSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                useSDKCreds:
+                                  type: boolean
+                              type: object
+                            subPath:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      parameters:
+                        items:
+                          properties:
+                            default:
+                              type: string
+                            description:
+                              type: string
+                            enum:
+                              items:
+                                type: string
+                              type: array
+                            globalName:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                default:
+                                  type: string
+                                event:
+                                  type: string
+                                expression:
+                                  type: string
+                                jqFilter:
+                                  type: string
+                                jsonPath:
+                                  type: string
+                                parameter:
+                                  type: string
+                                path:
+                                  type: string
+                                supplied:
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      generateName:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  workflowTemplateRef:
+                    properties:
+                      clusterScope:
+                        type: boolean
+                      name:
+                        type: string
+                    type: object
+                required:
+                - workflowTemplateRef
+                type: object
+            required:
+            - event
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_workflows.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflows.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    singular: workflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of the workflow
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: When the workflow was started
+      format: date-time
+      jsonPath: .status.startedAt
+      name: Age
+      type: date
+    - description: Human readable message indicating details about why the workflow
+        is in this condition.
+      jsonPath: .status.message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_workflowtaskresults.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowtaskresults.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowTaskResult
+    listKind: WorkflowTaskResultList
+    plural: workflowtaskresults
+    singular: workflowtaskresult
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          message:
+            type: string
+          metadata:
+            type: object
+          outputs:
+            properties:
+              artifacts:
+                items:
+                  properties:
+                    archive:
+                      properties:
+                        none:
+                          type: object
+                        tar:
+                          properties:
+                            compressionLevel:
+                              format: int32
+                              type: integer
+                          type: object
+                        zip:
+                          type: object
+                      type: object
+                    archiveLogs:
+                      type: boolean
+                    artifactGC:
+                      properties:
+                        podMetadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        serviceAccountName:
+                          type: string
+                        strategy:
+                          enum:
+                          - ""
+                          - OnWorkflowCompletion
+                          - OnWorkflowDeletion
+                          - Never
+                          type: string
+                      type: object
+                    artifactory:
+                      properties:
+                        passwordSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        url:
+                          type: string
+                        usernameSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - url
+                      type: object
+                    azure:
+                      properties:
+                        accountKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        blob:
+                          type: string
+                        container:
+                          type: string
+                        endpoint:
+                          type: string
+                        useSDKCreds:
+                          type: boolean
+                      required:
+                      - blob
+                      - container
+                      - endpoint
+                      type: object
+                    deleted:
+                      type: boolean
+                    from:
+                      type: string
+                    fromExpression:
+                      type: string
+                    gcs:
+                      properties:
+                        bucket:
+                          type: string
+                        key:
+                          type: string
+                        serviceAccountKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - key
+                      type: object
+                    git:
+                      properties:
+                        branch:
+                          type: string
+                        depth:
+                          format: int64
+                          type: integer
+                        disableSubmodules:
+                          type: boolean
+                        fetch:
+                          items:
+                            type: string
+                          type: array
+                        insecureIgnoreHostKey:
+                          type: boolean
+                        insecureSkipTLS:
+                          type: boolean
+                        passwordSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        repo:
+                          type: string
+                        revision:
+                          type: string
+                        singleBranch:
+                          type: boolean
+                        sshPrivateKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        usernameSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - repo
+                      type: object
+                    globalName:
+                      type: string
+                    hdfs:
+                      properties:
+                        addresses:
+                          items:
+                            type: string
+                          type: array
+                        dataTransferProtection:
+                          type: string
+                        force:
+                          type: boolean
+                        hdfsUser:
+                          type: string
+                        krbCCacheSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        krbConfigConfigMap:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        krbKeytabSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        krbRealm:
+                          type: string
+                        krbServicePrincipalName:
+                          type: string
+                        krbUsername:
+                          type: string
+                        path:
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    http:
+                      properties:
+                        auth:
+                          properties:
+                            basicAuth:
+                              properties:
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                usernameSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            clientCert:
+                              properties:
+                                clientCertSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                clientKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            oauth2:
+                              properties:
+                                clientIDSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                clientSecretSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                endpointParams:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                scopes:
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenURLSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        headers:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        url:
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    mode:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    optional:
+                      type: boolean
+                    oss:
+                      properties:
+                        accessKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        bucket:
+                          type: string
+                        createBucketIfNotPresent:
+                          type: boolean
+                        endpoint:
+                          type: string
+                        key:
+                          type: string
+                        lifecycleRule:
+                          properties:
+                            markDeletionAfterDays:
+                              format: int32
+                              type: integer
+                            markInfrequentAccessAfterDays:
+                              format: int32
+                              type: integer
+                          type: object
+                        secretKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        securityToken:
+                          type: string
+                        useSDKCreds:
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    path:
+                      type: string
+                    raw:
+                      properties:
+                        data:
+                          type: string
+                      required:
+                      - data
+                      type: object
+                    recurseMode:
+                      type: boolean
+                    s3:
+                      properties:
+                        accessKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        bucket:
+                          type: string
+                        caSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        createBucketIfNotPresent:
+                          properties:
+                            objectLocking:
+                              type: boolean
+                          type: object
+                        encryptionOptions:
+                          properties:
+                            enableEncryption:
+                              type: boolean
+                            kmsEncryptionContext:
+                              type: string
+                            kmsKeyId:
+                              type: string
+                            serverSideCustomerKeySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        endpoint:
+                          type: string
+                        insecure:
+                          type: boolean
+                        key:
+                          type: string
+                        region:
+                          type: string
+                        roleARN:
+                          type: string
+                        secretKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sessionTokenSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        useSDKCreds:
+                          type: boolean
+                      type: object
+                    subPath:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              exitCode:
+                type: string
+              parameters:
+                items:
+                  properties:
+                    default:
+                      type: string
+                    description:
+                      type: string
+                    enum:
+                      items:
+                        type: string
+                      type: array
+                    globalName:
+                      type: string
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        configMapKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        default:
+                          type: string
+                        event:
+                          type: string
+                        expression:
+                          type: string
+                        jqFilter:
+                          type: string
+                        jsonPath:
+                          type: string
+                        parameter:
+                          type: string
+                        path:
+                          type: string
+                        supplied:
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              result:
+                type: string
+            type: object
+          phase:
+            type: string
+          progress:
+            type: string
+        required:
+        - metadata
+        type: object
+    served: true
+    storage: true
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_workflowtasksets.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowtasksets.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowTaskSet
+    listKind: WorkflowTaskSetList
+    plural: workflowtasksets
+    shortNames:
+    - wfts
+    singular: workflowtaskset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: workflows/charts/argo-workflows/templates/crds/argoproj.io_workflowtemplates.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowtemplates.argoproj.io
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowTemplate
+    listKind: WorkflowTemplateList
+    plural: workflowtemplates
+    shortNames:
+    - wftmpl
+    singular: workflowtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflows-argo-workflows-workflow-controller
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumeclaims/finalizers
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workflowtasksets
+  - workflowtasksets/finalizers
+  - workflowartifactgctasks
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtaskresults
+  - workflowtaskresults/finalizers
+  verbs:
+  - list
+  - watch
+  - deletecollection
+- apiGroups:
+  - argoproj.io
+  resources:
+  - cronworkflows
+  - cronworkflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "policy"
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - postgres-argo-workflows-password
+  - postgres-argo-workflows-password
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - workflow-controller
+  - workflow-controller-lease
+  verbs:
+  - get
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  resourceNames:
+  - argo-workflows-agent-ca-certificates
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflows-argo-workflows-workflow-controller-cluster-template
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflows-argo-workflows-server
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - watch
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - postgres-argo-workflows-password
+  - postgres-argo-workflows-password
+  verbs:
+  - get
+- apiGroups:
+    - argoproj.io
+  resources:
+    - eventsources
+    - sensors
+    - workflows
+    - workfloweventbindings
+    - workflowtemplates
+    - cronworkflows
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - patch
+    - delete
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflows-argo-workflows-server-cluster-template
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+# Source: workflows/templates/argo-workflow-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-workflow
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "patch"]
+- apiGroups: [""]
+  resources: ["pods/logs"]
+  verbs: ["get", "watch"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: ["argoproj.io"]
+  resources: [
+    "workflowtaskresults",
+    ]
+  verbs: ["create","patch"] 
+- apiGroups: ["argoproj.io"]
+  resources: [
+    "workflowtasksets",
+    "workflowartifactgctasks",
+    ]
+  verbs: ["list", "watch"] 
+- apiGroups: ["argoproj.io"]
+  resources: [
+    "workflowtasksets/status",
+    "workflowartifactgctasks/status",
+    ]
+  verbs: ["patch"] 
+- apiGroups: ["kubeflow.org"]
+  resources: ["mpijobs"]
+  verbs: ["create", "get", "list", "watch", "update", "delete"]
+- apiGroups: ["kubeflow.org"]
+  resources: ["mpijobs/status"]
+  verbs: ["get", "watch"]
+---
+# Source: workflows/templates/kyverno-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:generate-resources
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - serviceaccounts
+  verbs:
+    - create
+    - update
+    - delete
+- apiGroups:
+    - "rbac.authorization.k8s.io"
+  resources:
+    - rolebindings
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - create
+    - update
+    - patch
+    - delete
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
+- apiGroups:
+    - "argoproj.io"
+  resources:
+   - workflows
+  verbs:
+    - get
+- apiGroups:
+    - "kueue.x-k8s.io"
+  resources:
+    - localqueues
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "kubeflow.org"
+  resources:
+  - mpijobs
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: workflows/templates/synchronize-artifact-s3-secret.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: artifact-s3-cloner
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "patch"]
+---
+# Source: workflows/templates/visit-member-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: visit-member
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - eventsources
+      - sensors
+      - workflows
+      - workfloweventbindings
+      - workflowtemplates
+      - clusterworkflowtemplates
+      - cronworkflows
+      - workflowtaskresults
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflows
+    verbs:
+      - create
+      - update
+      - patch
+---
+# Source: workflows/templates/workflows-user-service-account.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflows-user
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - clusterworkflowtemplates
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workflows-argo-workflows-workflow-controller
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflows-argo-workflows-workflow-controller
+subjects:
+  - kind: ServiceAccount
+    name: workflows-argo-workflows-workflow-controller
+    namespace: "gmm14360"
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workflows-argo-workflows-workflow-controller-cluster-template
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflows-argo-workflows-workflow-controller-cluster-template
+subjects:
+  - kind: ServiceAccount
+    name: workflows-argo-workflows-workflow-controller
+    namespace: "gmm14360"
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-crb.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workflows-argo-workflows-server
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflows-argo-workflows-server
+subjects:
+- kind: ServiceAccount
+  name: workflows-argo-workflows-server
+  namespace: "gmm14360"
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-crb.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workflows-argo-workflows-server-cluster-template
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflows-argo-workflows-server-cluster-template
+subjects:
+- kind: ServiceAccount
+  name: workflows-argo-workflows-server
+  namespace: "gmm14360"
+---
+# Source: workflows/templates/argo-workflow-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-workflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflow
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno
+---
+# Source: workflows/templates/kyverno-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno:generate-resources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:generate-resources
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno
+- kind: ServiceAccount
+  name: kyverno-admission-controller
+  namespace: kyverno
+---
+# Source: workflows/templates/synchronize-artifact-s3-secret.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: artifact-s3-cloner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: artifact-s3-cloner
+subjects:
+  - kind: ServiceAccount
+    name: artifact-s3-cloner
+    namespace: workflows
+---
+# Source: workflows/templates/visit-member-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: visit-member
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: visit-member
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno
+---
+# Source: workflows/templates/workflows-user-service-account.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workflows-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workflows-user
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflows-argo-workflows-workflow
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+  namespace: default
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - create
+      - patch
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflows-argo-workflows-workflow
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+  namespace: gmm14360
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtaskresults
+    verbs:
+      - create
+      - patch
+---
+# Source: workflows/templates/synchronize-artifact-s3-secret.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: artifact-s3-cloner
+  namespace: workflows
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["artifact-s3"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-rb.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflows-argo-workflows-workflow
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflows-argo-workflows-workflow
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflow
+    namespace: default
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-rb.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflows-argo-workflows-workflow
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+  namespace: gmm14360
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflows-argo-workflows-workflow
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflow
+    namespace: gmm14360
+---
+# Source: workflows/templates/synchronize-artifact-s3-secret.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: artifact-s3-cloner
+  namespace: workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: artifact-s3-cloner
+subjects:
+  - kind: ServiceAccount
+    name: artifact-s3-cloner
+    namespace: workflows
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflows-argo-workflows-workflow-controller
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/version: "v3.7.0"
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflows-argo-workflows-server
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/version: "v3.7.0"
+spec:
+  ports:
+  - port: 2746
+    targetPort: 2746
+  selector:
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: workflows/charts/oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+---
+# Source: workflows/charts/postgresql-ha/templates/pgpool/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflows-postgresql-ha-pgpool
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 4.5.4
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: pgpool
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: "postgresql"
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/component: pgpool
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflows-postgresql-ha-postgresql-metrics
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+    prometheus: kube-prometheus
+  annotations:
+    prometheus.io/port: "9187"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  
+  
+  ports:
+    - name: metrics
+      port: 9187
+      targetPort: metrics
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/component: postgresql
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflows-postgresql-ha-postgresql-headless
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: false
+  ports:
+    - name: "postgresql"
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/component: postgresql
+    role: data
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflows-postgresql-ha-postgresql
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - name: "postgresql"
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/component: postgresql
+    role: data
+---
+# Source: workflows/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflows-argo-workflows-workflow-controller
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-workflow-controller
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: workflow-controller
+    app: workflow-controller
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/version: "v3.7.0"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-workflow-controller
+      app.kubernetes.io/instance: workflows
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: argo-workflows-0.45.21
+        app.kubernetes.io/name: argo-workflows-workflow-controller
+        app.kubernetes.io/instance: workflows
+        app.kubernetes.io/component: workflow-controller
+        app: workflow-controller
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: argo-workflows
+        app.kubernetes.io/version: "v3.7.0"
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: workflows-argo-workflows-workflow-controller
+      containers:
+        - name: controller
+          image: "quay.io/argoproj/workflow-controller:v3.7.0"
+          imagePullPolicy: Always
+          command: [ "workflow-controller" ]
+          args:
+          - "--configmap"
+          - "workflows-argo-workflows-workflow-controller-configmap"
+          - "--executor-image"
+          - "quay.io/argoproj/argoexec:v3.7.0"
+          - "--loglevel"
+          - "info"
+          - "--gloglevel"
+          - "0"
+          - "--log-format"
+          - "text"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          env:
+            - name: ARGO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMES
+              value: v1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - containerPort: 6060
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 6060
+            initialDelaySeconds: 90
+            periodSeconds: 60
+            timeoutSeconds: 30
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: workflows/charts/argo-workflows/templates/server/server-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflows-argo-workflows-server
+  namespace: "gmm14360"
+  labels:
+    helm.sh/chart: argo-workflows-0.45.21
+    app.kubernetes.io/name: argo-workflows-server
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/component: server
+    app: server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-workflows
+    app.kubernetes.io/version: "v3.7.0"
+spec:
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-server
+      app.kubernetes.io/instance: workflows
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: argo-workflows-0.45.21
+        app.kubernetes.io/name: argo-workflows-server
+        app.kubernetes.io/instance: workflows
+        app.kubernetes.io/component: server
+        app: server
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: argo-workflows
+        app.kubernetes.io/version: "v3.7.0"
+      annotations:
+        checksum/cm: 57816a5fc8ff363a9c04edd14eeb65ac0e4cc8f33f07c4095167c4a8a78cc026
+    spec:
+      serviceAccountName: workflows-argo-workflows-server
+      containers:
+        - name: argo-server
+          image: "quay.io/argoproj/argocli:v3.7.0"
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+          args:
+          - server
+          - --configmap=workflows-argo-workflows-workflow-controller-configmap
+          - "--auth-mode=client"
+          - "--secure=false"
+          - "--loglevel"
+          - "info"
+          - "--gloglevel"
+          - "0"
+          - "--log-format"
+          - "text"
+          ports:
+          - name: web
+            containerPort: 2746
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 2746
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          env:
+            - name: IN_CLUSTER
+              value: "true"
+            - name: ARGO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: ARGO_BASE_HREF
+              value: "/"
+            - name: FIRST_TIME_USER_MODAL
+              value: "false"
+            - name: FEEDBACK_MODAL
+              value: "false"
+            - name: NEW_VERSION_MODAL
+              value: "false"
+            - name: POD_NAMES
+              value: v1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: workflows/charts/oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+spec:
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: workflows
+  template:
+    metadata:
+      annotations:
+        checksum/config: 977bc06d56d02a5195fe3755be8e145b0a033a67a3b70e9c6989cde2e2725d27
+        checksum/alpha-config: 862167f8c72d7b014658f5ae56bf919f29f48f71a491c539fa57daade7c4e0ca
+        checksum/secret: 8fa6fdae65861caa2986544b8860a5205be1937328c8ec2bad6bad076b9e2425
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-7.8.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: workflows
+        app.kubernetes.io/version: "7.7.1"
+    spec:
+      serviceAccountName: workflows-oauth2-proxy
+      automountServiceAccountToken: true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.7.1"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --alpha-config=/etc/oauth2_proxy/oauth2_proxy.yml
+          - --cookie-refresh=55s
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  workflows-oauth2-proxy
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  workflows-oauth2-proxy
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  workflows-oauth2-proxy
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          {}
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.yml
+          name: configalpha
+          subPath: oauth2_proxy.yml
+        - mountPath: /etc/alpha
+          name: secret
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: workflows-oauth2-proxy
+        name: configmain
+      - secret:
+          defaultMode: 420
+          secretName: workflows-oauth2-proxy-alpha
+        name: configalpha
+      - name: secret
+        secret:
+          items:
+          - key: secret
+            path: secret
+          secretName: argo-server-sso
+---
+# Source: workflows/charts/postgresql-ha/templates/pgpool/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflows-postgresql-ha-pgpool
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 4.5.4
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: pgpool
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: pgpool
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: workflows
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql-ha
+        app.kubernetes.io/version: 4.5.4
+        helm.sh/chart: postgresql-ha-14.3.9
+        app.kubernetes.io/component: pgpool
+    spec:
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: workflows
+                    app.kubernetes.io/name: postgresql-ha
+                    app.kubernetes.io/component: pgpool
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
+      serviceAccountName: workflows-postgresql-ha
+      # Auxiliary vars to populate environment variables
+      containers:
+        - name: pgpool
+          image: docker.io/bitnamilegacy/pgpool:4.5.4-debian-12-r6
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: PGPOOL_POSTGRES_CUSTOM_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-application-passwords
+                  key: usernames
+            - name: PGPOOL_POSTGRES_CUSTOM_PASSWORDS
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-application-passwords
+                  key: passwords
+            - name: PGPOOL_BACKEND_NODES
+              value: 0:workflows-postgresql-ha-postgresql-0.workflows-postgresql-ha-postgresql-headless:5432,1:workflows-postgresql-ha-postgresql-1.workflows-postgresql-ha-postgresql-headless:5432,2:workflows-postgresql-ha-postgresql-2.workflows-postgresql-ha-postgresql-headless:5432,
+            - name: PGPOOL_SR_CHECK_USER
+              value: "repmgr"
+            - name: PGPOOL_SR_CHECK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-passwords
+                  key: repmgr-password
+            - name: PGPOOL_SR_CHECK_DATABASE
+              value: "postgres"
+            - name: PGPOOL_ENABLE_LDAP
+              value: "no"
+            - name: PGPOOL_POSTGRES_USERNAME
+              value: "postgres"
+            - name: PGPOOL_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-passwords
+                  key: password
+            - name: PGPOOL_ADMIN_USERNAME
+              value: "admin"
+            - name: PGPOOL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pgpool-passwords
+                  key: admin-password
+            - name: PGPOOL_AUTHENTICATION_METHOD
+              value: "scram-sha-256"
+            - name: PGPOOL_ENABLE_LOAD_BALANCING
+              value: "yes"
+            - name: PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE
+              value: "transaction"
+            - name: PGPOOL_ENABLE_LOG_CONNECTIONS
+              value: "no"
+            - name: PGPOOL_ENABLE_LOG_HOSTNAME
+              value: "yes"
+            - name: PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT
+              value: "no"
+            - name: PGPOOL_RESERVED_CONNECTIONS
+              value: '1'
+            - name: PGPOOL_CHILD_LIFE_TIME
+              value: ""
+            - name: PGPOOL_ENABLE_TLS
+              value: "no"
+            - name: PGPOOL_HEALTH_CHECK_PSQL_TIMEOUT
+              value: "6"
+          envFrom:
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /opt/bitnami/scripts/pgpool/healthcheck.sh
+          readinessProbe:
+            failureThreshold: 5
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - bash
+                - -ec
+                - 'PGPASSWORD=$PGPOOL_POSTGRES_PASSWORD psql -U "postgres" -d "postgres" -h /opt/bitnami/pgpool/tmp -tA -c "SELECT 1" >/dev/null'
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/pgpool/etc
+              subPath: app-etc-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/pgpool/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/pgpool/tmp
+              subPath: app-tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/pgpool/logs
+              subPath: app-logs-dir
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+---
+# Source: workflows/charts/postgresql-ha/templates/postgresql/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: workflows-postgresql-ha-postgresql
+  namespace: "gmm14360"
+  labels:
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql-ha
+    app.kubernetes.io/version: 16.5.0
+    helm.sh/chart: postgresql-ha-14.3.9
+    app.kubernetes.io/component: postgresql
+    role: data
+spec:
+  replicas: 3
+  podManagementPolicy: "Parallel"
+  serviceName: workflows-postgresql-ha-postgresql-headless
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: workflows
+      app.kubernetes.io/name: postgresql-ha
+      app.kubernetes.io/component: postgresql
+      role: data
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: workflows
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql-ha
+        app.kubernetes.io/version: 16.5.0
+        helm.sh/chart: postgresql-ha-14.3.9
+        app.kubernetes.io/component: postgresql
+        role: data
+      annotations:
+        prometheus.io/port: "9187"
+        prometheus.io/scrape: "true"
+    spec:
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: workflows
+                  app.kubernetes.io/name: postgresql-ha
+                  app.kubernetes.io/component: postgresql
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        supplementalGroups: []
+        sysctls: []
+      serviceAccountName: workflows-postgresql-ha
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql-repmgr:16.5.0-debian-12-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /pre-stop.sh
+                  - "25"
+          # Auxiliary vars to populate environment variables
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            # PostgreSQL configuration
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-passwords
+                  key: password
+            - name: POSTGRES_DB
+              value: "postgres"
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "true"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit, repmgr"
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            # Repmgr configuration
+            - name: REPMGR_PORT_NUMBER
+              value: "5432"
+            - name: REPMGR_PRIMARY_PORT
+              value: "5432"
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: REPMGR_UPGRADE_EXTENSION
+              value: "no"
+            - name: REPMGR_PGHBA_TRUST_ALL
+              value: "no"
+            - name: REPMGR_MOUNTED_CONF_DIR
+              value: "/bitnami/repmgr/conf"
+            - name: REPMGR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REPMGR_PARTNER_NODES
+              value: workflows-postgresql-ha-postgresql-0.workflows-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local,workflows-postgresql-ha-postgresql-1.workflows-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local,workflows-postgresql-ha-postgresql-2.workflows-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local,
+            - name: REPMGR_PRIMARY_HOST
+              value: "workflows-postgresql-ha-postgresql-0.workflows-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local"
+            - name: REPMGR_NODE_NAME
+              value: "$(MY_POD_NAME)"
+            - name: REPMGR_NODE_NETWORK_NAME
+              value: "$(MY_POD_NAME).workflows-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local"
+            - name: REPMGR_NODE_TYPE
+              value: "data"
+            - name: REPMGR_LOG_LEVEL
+              value: "NOTICE"
+            - name: REPMGR_CONNECT_TIMEOUT
+              value: "5"
+            - name: REPMGR_RECONNECT_ATTEMPTS
+              value: "2"
+            - name: REPMGR_RECONNECT_INTERVAL
+              value: "3"
+            - name: REPMGR_USERNAME
+              value: "repmgr"
+            - name: REPMGR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-passwords
+                  key: repmgr-password
+            - name: REPMGR_DATABASE
+              value: "repmgr"
+            - name: REPMGR_FENCE_OLD_PRIMARY
+              value: "no"
+            - name: REPMGR_CHILD_NODES_CHECK_INTERVAL
+              value: "5"
+            - name: REPMGR_CHILD_NODES_CONNECTED_MIN_COUNT
+              value: "1"
+            - name: REPMGR_CHILD_NODES_DISCONNECT_TIMEOUT
+              value: "30"
+          envFrom:
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - bash
+                - -ec
+                - 'ps waux | grep "data standby clone" | grep -v grep || PGPASSWORD=$POSTGRES_PASSWORD psql -w -U "postgres" -d "postgres" -h 127.0.0.1 -p 5432 -c "SELECT 1"'
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - bash
+                - -ec
+                - |
+                  exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/repmgr/conf
+              subPath: repmgr-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/repmgr/tmp
+              subPath: repmgr-tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/repmgr/logs
+              subPath: repmgr-logs-dir
+            - name: custom-init-scripts-secret
+              mountPath: /docker-entrypoint-initdb.d/secret
+            - name: data
+              mountPath: /bitnami/postgresql
+            - name: hooks-scripts
+              mountPath: /pre-stop.sh
+              subPath: pre-stop.sh
+            - name: hooks-scripts
+              mountPath: /readiness-probe.sh
+              subPath: readiness-probe.sh
+        - name: metrics
+          image: docker.io/bitnamilegacy/postgres-exporter:0.16.0-debian-12-r1
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: PG_EXPORTER_WEB_LISTEN_ADDRESS
+              value: :9187
+            - name: DATA_SOURCE_URI
+              value: "127.0.0.1:5432/postgres?sslmode=disable"
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-passwords
+                  key: password
+            - name: DATA_SOURCE_USER
+              value: "postgres"
+          envFrom:
+          ports:
+            - name: metrics
+              containerPort: 9187
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: metrics
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /
+              port: metrics
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: hooks-scripts
+          configMap:
+            name: workflows-postgresql-ha-postgresql-hooks-scripts
+            defaultMode: 0755
+        - name: custom-init-scripts-secret
+          secret:
+            secretName: postgres-initdb-script
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "50Gi"
+        storageClassName: db-nvme-storage
+---
+# Source: workflows/templates/synchronize-artifact-s3-secret.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: copy-host-secret-artifact-s3
+  namespace: workflows
+spec:
+  # Suspended: intended to be triggered manually
+  # eg kubectl create job --from=cronjob/copy-host-secret-artifact-s3 -nworkflows copy-host-secret-artifact-s3
+  suspend: true
+  schedule: "0 3 * * *" # schedule has no impact if suspended
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 300
+      template:
+        spec:
+          serviceAccountName: artifact-s3-cloner
+          restartPolicy: Never
+          containers:
+            - name: sync
+              image: alpine/kubectl:1.34.2
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+
+                  SOURCE_NAMESPACE="${SOURCE_NAMESPACE:-workflows}"
+                  SECRET_NAME="${SECRET_NAME:-artifact-s3}"
+                  LABEL_SELECTOR="${LABEL_SELECTOR:-app.kubernetes.io/managed-by=sessionspaces}"
+
+                  echo "Starting sync of ${SOURCE_NAMESPACE}/${SECRET_NAME} to namespaces with ${LABEL_SELECTOR}"
+
+                  if ! kubectl -n "${SOURCE_NAMESPACE}" get secret "${SECRET_NAME}" >/dev/null 2>&1; then
+                    echo "ERROR: source secret ${SOURCE_NAMESPACE}/${SECRET_NAME} not found" >&2
+                    exit 1
+                  fi
+
+                  ACCESS_KEY_B64="$(kubectl -n "${SOURCE_NAMESPACE}" get secret "${SECRET_NAME}" -o jsonpath='{.data.access-key}' || true)"
+                  SECRET_KEY_B64="$(kubectl -n "${SOURCE_NAMESPACE}" get secret "${SECRET_NAME}" -o jsonpath='{.data.secret-key}' || true)"
+                  SECRET_TYPE="$(kubectl -n "${SOURCE_NAMESPACE}" get secret "${SECRET_NAME}" -o jsonpath='{.type}' || true)"
+
+                  if [ -z "${ACCESS_KEY_B64}" ] || [ -z "${SECRET_KEY_B64}" ]; then
+                    echo "ERROR: expected keys 'access-key' and 'secret-key' missing" >&2
+                    exit 2
+                  fi
+
+                  ACCESS_KEY_VALUE="$(printf '%s' "${ACCESS_KEY_B64}" | base64 -d 2>/dev/null || true)"
+                  SECRET_KEY_VALUE="$(printf '%s' "${SECRET_KEY_B64}" | base64 -d 2>/dev/null || true)"
+                  [ -n "${ACCESS_KEY_VALUE}" ] || { echo "ERROR: failed to decode access-key"; exit 3; }
+                  [ -n "${SECRET_KEY_VALUE}" ] || { echo "ERROR: failed to decode secret-key"; exit 4; }
+                  [ -n "${SECRET_TYPE}" ] || SECRET_TYPE="Opaque"
+
+                  # Iterate target namespaces with the label and apply secret
+                  for ns in $(kubectl get ns -l "${LABEL_SELECTOR}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
+                    echo "Syncing into namespace: ${ns}"               
+                    kubectl -n "${ns}" create secret generic "${SECRET_NAME}" \
+                                        --type="${SECRET_TYPE}" \
+                                        --from-literal=access-key="${ACCESS_KEY_VALUE}" \
+                                        --from-literal=secret-key="${SECRET_KEY_VALUE}" \
+                                        --dry-run=client -o yaml \
+                                      | kubectl -n "${ns}" apply --server-side --force-conflicts -f -
+                  done
+
+                  echo "Sync completed."
+              env:
+                - name: SOURCE_NAMESPACE
+                  value: "workflows"
+                - name: SECRET_NAME
+                  value: "artifact-s3"
+                - name: LABEL_SELECTOR
+                  value: "app.kubernetes.io/managed-by=sessionspaces"
+---
+# Source: workflows/charts/oauth2-proxy/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.8.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: workflows
+    app.kubernetes.io/version: "7.7.1"
+  name: workflows-oauth2-proxy
+  namespace: gmm14360
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
+spec:
+  rules:
+    - host: "argo-workflows.workflows.diamond.ac.uk"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: workflows-oauth2-proxy
+                port:
+                  number: 80
+  tls:
+    - hosts:
+      - argo-workflows.workflows.diamond.ac.uk
+      secretName: workflows-tls-cert
+---
+# Source: workflows/templates/artifact-s3-clusterpolicy.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workflows-artifact-s3
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: prohibit-artifact-s3-secret-usage
+      match:
+        resources:
+          kinds:
+            - Pod
+          namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+      validate:
+        message: "The artifact-s3 secret cannot be used by workflow pods"
+        pattern:
+          spec:
+            =(volumes):
+              - (name): "!artifact-s3"
+                =(secret):
+                  secretName: "!artifact-s3"
+            =(initContainers):
+              - (name): "!init"
+                image: "!quay.io/argoproj/argoexec:?"
+                =(env):
+                  - =(valueFrom):
+                      =(secretKeyRef):
+                        name: "!artifact-s3"
+                =(volumeMounts):
+                  - name: "!artifact-s3"
+            =(ephemeralContainers):
+              - name: "*"
+                =(volumeMounts):
+                  - name: "!artifact-s3"
+            containers:
+              - (name): "!wait"
+                image: "!quay.io/argoproj/argoexec:?"
+                =(env):
+                  - =(valueFrom):
+                      =(secretKeyRef):
+                        name: "!artifact-s3"
+                =(volumeMounts):
+                  - name: "!artifact-s3"
+---
+# Source: workflows/templates/default-localqueue-clusterpolicy.yaml
+# Design: Policy creates LocalQueues for new matching namespaces; post-install Job handles existing ones.
+# This avoids Kyverno's generateExisting limitations with large namespace counts.
+# Note: May fail if matched namespaces grow excessively from zero (clean install); upstream Kyverno bug.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-default-localqueue
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: create-localqueue-for-session
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+    generate:
+      synchronize: true
+      apiVersion: kueue.x-k8s.io/v1beta1
+      kind: LocalQueue
+      name: default-queue
+      namespace: "{{request.object.metadata.name}}"
+      data:
+        spec:
+          clusterQueue: default-queue
+---
+# Source: workflows/templates/default-pod-resources.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pod-default-resources
+spec:
+  rules:
+    - name: set-pod-default-resources
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  kueue.x-k8s.io/managed: "true"
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers"
+            preconditions:
+              all:
+              - key: "{{element.name || ''}}"
+                operator: NotEquals
+                value: "wait"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - (name): "{{element.name}}"
+                    resources:
+                      requests:
+                        +(cpu): "1"
+                        +(memory): "250Mi"
+                      limits:
+                        +(cpu): "1"
+                        +(memory): "250Mi"
+          - list: "request.object.spec.initContainers || []"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - (name): "{{element.name}}"
+                    resources:
+                      requests:
+                        +(cpu): "1"
+                        +(memory): "250Mi"
+                      limits:
+                        +(cpu): "1"
+                        +(memory): "250Mi"
+---
+# Source: workflows/templates/default-queuename-clusterpolicy.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: default-queuename
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: set-default-queuename
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            operations:
+              - CREATE
+      preconditions:
+        all:
+        - key: "{{ request.object.spec.podMetadata.labels.\"kueue.x-k8s.io/queue-name\" || '' }}"
+          operator: Equals
+          value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            podMetadata:
+              labels:
+                kueue.x-k8s.io/queue-name: default-queue
+
+    - name: validate-queuename
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            operations:
+              - CREATE
+              - UPDATE
+      validate:
+        message: "The label kueue.x-k8s.io/queue-name must be default-queue"
+        deny:
+          conditions:
+            all:
+            - key: "{{ request.object.spec.podMetadata.labels.\"kueue.x-k8s.io/queue-name\" || 'default-queue' }}"
+              operator: AnyNotIn
+              value:
+                - default-queue
+
+    - name: validate-mpijob-queuename
+      match:
+        any:
+        - resources:
+            kinds:
+            - kubeflow.org/*/MPIJob
+            operations:
+              - CREATE
+              - UPDATE
+      validate:
+        message: "The label kueue.x-k8s.io/queue-name must be default-queue"
+        deny:
+          conditions:
+            all:
+            - key: "{{ request.object.metadata.labels.\"kueue.x-k8s.io/queue-name\" || '' }}"
+              operator: AnyNotIn
+              value:
+                - default-queue
+---
+# Source: workflows/templates/pod-gc-clusterpolicy.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workflows-pod-gc
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: apply-default-pod-gc
+      match:
+        resources:
+          kinds:
+            - argoproj.io/*/Workflow
+          operations:
+            - CREATE
+      mutate:
+        patchStrategicMerge:
+          spec:
+            +(podGC):
+              +(strategy): OnPodCompletion
+              +(deleteDelayDuration): 60s
+---
+# Source: workflows/templates/sessionspace-clusterpolicy.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workflows-sessionspace
+spec:
+  validationFailureAction: Enforce
+  background: false
+  generateExisting: true
+  mutateExistingOnPolicyUpdate: true
+  rules:
+    - name: add-workflow-label-to-configmap
+      match:
+        resources:
+          kinds:
+            - ConfigMap
+          names:
+            - sessionspaces
+          selector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+          namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+      preconditions:
+        all:
+        - key: "{{ request.object.metadata.labels.\"workflows.argoproj.io/configmap-type\" || '' }}"
+          operator: NotEquals
+          value: Parameter
+      mutate:
+        targets:
+          - apiVersion: v1
+            kind: ConfigMap
+            name: sessionspaces
+            namespace: "{{request.object.metadata.namespace}}"
+        patchStrategicMerge:
+          metadata:
+            labels:
+              workflows.argoproj.io/configmap-type: Parameter
+    - name: generate-visit-member-role-binding
+      match:
+        resources:
+          kinds:
+            - ConfigMap
+          names:
+            - sessionspaces
+          selector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+          namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+      context:
+        - name: sessionspace
+          configMap:
+            name: sessionspaces
+            namespace: "{{request.object.metadata.namespace}}"
+      generate:
+        synchronize: true
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: visit-member
+        namespace: "{{request.namespace}}"
+        data:
+          subjects: |-
+            {{
+              sessionspace.data.members | parse_json(@)[].{"apiGroup": 'rbac.authorization.k8s.io', "kind": 'User', "name": join('', ['oidc:', @])}
+            }}
+          roleRef:
+            kind: ClusterRole
+            name: visit-member
+            apiGroup: rbac.authorization.k8s.io
+    - name: generate-argo-workflow-service-account
+      match:
+        resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+      generate:
+        apiVersion: v1
+        kind: ServiceAccount
+        name: argo-workflow
+        namespace: "{{request.object.metadata.name}}"
+    - name: generate-argo-workflow-role-binding
+      skipBackgroundRequests: false
+      match:
+        resources:
+          kinds:
+            - ServiceAccount
+          names:
+            - argo-workflow
+          namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: sessionspaces
+      generate:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: argo-workflow
+        namespace: "{{request.namespace}}"
+        data:
+          metadata:
+            ownerReferences:
+              - apiVersion: v1
+                kind: ServiceAccount
+                name: "{{request.object.metadata.name}}"
+                uid: "{{request.object.metadata.uid}}"
+          subjects:
+            - kind: ServiceAccount
+              name: argo-workflow
+              namespace: "{{request.namespace}}"
+          roleRef:
+            kind: ClusterRole
+            name: argo-workflow
+            apiGroup: rbac.authorization.k8s.io
+---
+# Source: workflows/templates/workflow-label-clusterpolicy.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workflows-posix-uid-label
+spec:
+  background: false
+  validationFailureAction: Enforce
+  rules:
+    - name: apply-posix-uid-label
+      match:
+        resources:
+          kinds:
+            - argoproj.io/*/Workflow
+          operations:
+            - CREATE
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ request.userInfo.extra | "workflows.diamond.ac.uk/posixuid" | [0] }}'
+---
+# Source: workflows/templates/workloadpriority-clusterpolicy.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workloadpriority
+spec:
+  validationFailureAction: Enforce
+  rules:
+    - name: standard-workload-priority
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            operations:
+              - CREATE
+      preconditions:
+        all:
+        - key: "{{ request.object.metadata.annotations.\"workflows.diamond.ac.uk/type\" || 'standard' }}"
+          operator: Equals
+          value: "standard"
+        - key: "{{ request.object.spec.podMetadata.labels.\"kueue.x-k8s.io/priority-class\" || '' }}"
+          operator: Equals
+          value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            podMetadata:
+              labels:
+                kueue.x-k8s.io/priority-class: medium
+
+    - name: live-workload-priority
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            annotations:
+              workflows.diamond.ac.uk/type: "live"
+            operations:
+              - CREATE
+      preconditions:
+        all:
+        - key: "{{ request.object.spec.podMetadata.labels.\"kueue.x-k8s.io/priority-class\" || '' }}"
+          operator: Equals
+          value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            podMetadata:
+              labels:
+                kueue.x-k8s.io/priority-class: high
+
+    - name: low-workload-priority
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            annotations:
+              workflows.diamond.ac.uk/type: "test"
+            operations:
+              - CREATE
+      preconditions:
+        all:
+        - key: "{{ request.object.spec.podMetadata.labels.\"kueue.x-k8s.io/priority-class\" || '' }}"
+          operator: Equals
+          value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            podMetadata:
+              labels:
+                kueue.x-k8s.io/priority-class: low
+
+    - name: validate-workflow-type
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            operations:
+            - CREATE
+      validate:
+        message: "The annotation workflows.diamond.ac.uk/type must be 'standard', 'live', or 'test'."
+        deny:
+          conditions:
+            all:
+            - key: "{{ request.object.metadata.annotations.\"workflows.diamond.ac.uk/type\" || 'standard' }}"
+              operator: AnyNotIn
+              value:
+              - standard
+              - live
+              - test
+
+    - name: validate-kueue-labels
+      match:
+        any:
+        - resources:
+            kinds:
+            - argoproj.io/*/Workflow
+            operations:
+            - CREATE
+            - UPDATE
+      validate:
+        message: "Workload priority labels must match the workflows.diamond.ac.uk/type annotation."
+        deny:
+          conditions:
+            all:
+            - key: "{{ request.object.spec.podMetadata.labels.\"kueue.x-k8s.io/priority-class\"  }}"
+              operator: NotEquals
+              value: "{{ request.object.metadata.annotations.\"workflows.diamond.ac.uk/type\" == 'live' && 'high' || request.object.metadata.annotations.\"workflows.diamond.ac.uk/type\" == 'test' && 'low' || 'medium'  }}"
+---
+# Source: workflows/templates/sessionspace-clusterpolicy.yaml
+apiVersion: policies.kyverno.io/v1alpha1
+kind: GeneratingPolicy
+metadata:
+  name: copy-host-secret-artifact-s3
+spec:
+  evaluation:
+    generateExisting:
+      enabled: false
+    synchronize:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE"]
+      resources:   ["namespaces"]
+    namespaceSelector:
+      matchLabels:
+          app.kubernetes.io/managed-by: sessionspaces
+  variables:
+    - name: targetNs
+      expression: "object.metadata.name"
+    - name: sourceSecret
+      expression: resource.Get("v1", "secrets", "workflows", "artifact-s3")
+  generate:
+    - expression: generator.Apply(variables.targetNs, [variables.sourceSecret])
+---
+# Source: workflows/templates/postgres-secrets-policy.yaml
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: generate-postgres-secrets
+  namespace: gmm14360
+spec:
+  rules:
+    - name: generate-postgres-application-passwords
+      match:
+        any:
+          - resources:
+              kinds: ["Secret"]
+              names:
+                - postgres-argo-workflows-password
+                - postgres-auth-service-password
+      context:
+        - name: argoSecret
+          apiCall:
+            urlPath: /api/v1/namespaces/gmm14360/secrets/postgres-argo-workflows-password
+        - name: authSecret
+          apiCall:
+            urlPath: "/api/v1/namespaces/gmm14360/secrets/postgres-auth-service-password"
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: postgres-application-passwords
+        namespace: gmm14360
+        synchronize: true
+        generateExisting: true
+        data:
+          type: Opaque
+          stringData:
+            usernames: "{{ join(',', [
+              base64_decode(argoSecret.data.username || ''),
+              base64_decode(authSecret.data.username || '')
+            ]) }}"
+            passwords: "{{ join(',', [
+              base64_decode(argoSecret.data.password || ''),
+              base64_decode(authSecret.data.password || '')
+            ]) }}"
+
+    - name: generate-initdb-script
+      match:
+        any:
+          - resources:
+              kinds: ["Secret"]
+              names:
+                - postgres-argo-workflows-password
+                - postgres-auth-service-password
+      context:
+        - name: argoSecret
+          apiCall:
+            urlPath: "/api/v1/namespaces/gmm14360/secrets/postgres-argo-workflows-password"
+        - name: authSecret
+          apiCall:
+            urlPath: "/api/v1/namespaces/gmm14360/secrets/postgres-auth-service-password"
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: postgres-initdb-script
+        namespace: gmm14360
+        synchronize: true
+        generateExisting: true
+        data:
+          kind: Secret
+          type: Opaque
+          data:
+            init.sql: |
+              {{ base64_encode(join('', [
+                'CREATE USER argo_workflows WITH PASSWORD \'', 
+                base64_decode(argoSecret.data.password || ''), 
+                '\'; ',
+                'CREATE DATABASE argo_workflows OWNER argo_workflows; ',
+                'CREATE USER auth_user WITH PASSWORD \'', 
+                base64_decode(authSecret.data.password || ''), 
+                '\'; ',
+                'CREATE DATABASE auth_service OWNER auth_user;'
+              ])) }}

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -1,5 +1,6 @@
 argo-workflows:
   enabled: true
+
   artifactRepository:
     archiveLogs: true
     s3:
@@ -12,81 +13,131 @@ argo-workflows:
       endpoint: sci-nas-s3.diamond.ac.uk
       bucket: k8s-workflows-test
       region: unsupported
+
   controller:
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "500m"
+      limits:
+        memory: "4Gi"
+        cpu: "1000m"
+
     metricsConfig:
       enabled: true
       secure: false
       scheme: http
+
     replicas: 2
+
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9090"
+
     pdb:
       minAvailable: 1
+
     persistence:
       archive: true
       postgresql:
         host: workflows-postgresql-ha-pgpool
-        # TODO: Use templated value: {{ .Release.Name }}-postgresql-ha-pgpool
         port: 5432
         database: argo_workflows
         tableName: workflows
+
         userNameSecret:
           name: postgres-argo-workflows-password
           key: username
+
         passwordSecret:
           name: postgres-argo-workflows-password
           key: password
+
     workflowDefaults:
       spec:
+        podSpecPatch: |
+          containers:
+            - name: main
+              resources:
+                requests:
+                  memory: "2Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "4Gi"
+                  cpu: "1000m"
+
         serviceAccountName: argo-workflow
+
         ttlStrategy:
           secondsAfterCompletion: 300
           secondsAfterFailure: 60
+
         tolerations:
-        - key: nodegroup
-          operator: Equal
-          value: workflows
-          effect: NoSchedule
-        - key: nodetype
-          operator: Equal
-          value: cs05r_gpfs
-          effect: PreferNoSchedule
+          - key: nodegroup
+            operator: Equal
+            value: workflows
+            effect: NoSchedule
+
+          - key: nodetype
+            operator: Equal
+            value: cs05r_gpfs
+            effect: PreferNoSchedule
+
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                - key: nodegroup
-                  operator: In
-                  values:
-                  - workflows
+              - weight: 100
+                preference:
+                  matchExpressions:
+                    - key: nodegroup
+                      operator: In
+                      values:
+                        - workflows
+
     extraEnv:
       - name: POD_NAMES
         value: "v1"
+
   server:
+    resources:
+      requests:
+        memory: "1Gi"
+        cpu: "1000m"
+      limits:
+        memory: "2Gi"
+        cpu: "2000m"
+
     replicas: 3
-    authModes: ["client"]
+
+    authModes:
+      - client
+
     extraEnv:
       - name: FIRST_TIME_USER_MODAL
         value: "false"
+
       - name: FEEDBACK_MODAL
         value: "false"
+
       - name: NEW_VERSION_MODAL
         value: "false"
+
       - name: POD_NAMES
         value: "v1"
+
   createAggregateRoles: false
 
 postgresql-ha:
   enabled: true
+
   postgresql:
     image:
       repository: bitnamilegacy/postgresql-repmgr
+
     existingSecret: postgres-passwords
     initdbScriptsSecret: postgres-initdb-script
     podAntiAffinityPreset: hard
+
     resources:
       requests:
         cpu: 500m
@@ -94,11 +145,14 @@ postgresql-ha:
       limits:
         cpu: 2000m
         memory: 2Gi
+
   pgpool:
     image:
       repository: bitnamilegacy/pgpool
+
     existingSecret: pgpool-passwords
     customUsersSecret: postgres-application-passwords
+
     resources:
       requests:
         cpu: 500m
@@ -106,34 +160,45 @@ postgresql-ha:
       limits:
         cpu: 1000m
         memory: 4Gi
+
   persistence:
     storageClass: db-nvme-storage
     size: 50Gi
+
   metrics:
     enabled: true
+
     image:
       repository: bitnamilegacy/postgres-exporter
 
 oauth2-proxy:
   enabled: true
+
   replicaCount: 3
+
   ingress:
     enabled: true
     pathType: Prefix
+
     hosts:
       - argo-workflows.workflows.diamond.ac.uk
+
     path: /
+
     tls:
       - secretName: workflows-tls-cert
         hosts:
           - argo-workflows.workflows.diamond.ac.uk
+
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+
   config:
     configFile: |-
       email_domains = [
         "*"
       ]
+
       skip_auth_routes = [
         "OPTIONS=^/$",
         "GET=^/api/",
@@ -147,15 +212,19 @@ oauth2-proxy:
         "GET=^/input-artifacts/",
         "GET=^/assets/"
       ]
+
       skip_provider_button = true
+
   alphaConfig:
     enabled: true
+
     configFile: |-
       upstreamConfig:
         upstreams:
           - id: argo-workflows-server
             path: /
             uri: http://{{ .Release.Name }}-argo-workflows-server:2746
+
     configData:
       injectRequestHeaders:
         - name: Authorization
@@ -163,35 +232,45 @@ oauth2-proxy:
             - claim: access_token
               prefix: "Bearer "
           preserveRequestValue: true
+
       injectResponseHeaders:
         - name: Identity
           values:
             - claim: id_token
+
       providers:
         - provider: oidc
           scope: "openid posix-uid profile email fedid"
           clientId: workflows-argo-server
           clientSecretFile: /etc/alpha/secret
           id: authn
+
           oidcConfig:
             issuerURL: https://identity.diamond.ac.uk/realms/dls
             insecureAllowUnverifiedEmail: true
+
             audienceClaims:
               - aud
+
             emailClaim: email
             userIDClaim: fedid
+
             extraAudiences:
               - workflows-cluster-staging
               - graph
+
   extraArgs:
     - --cookie-refresh=55s
+
   extraVolumes:
     - name: secret
       secret:
         secretName: argo-server-sso
+
         items:
           - key: secret
             path: secret
+
   extraVolumeMounts:
     - name: secret
       mountPath: /etc/alpha
@@ -199,6 +278,7 @@ oauth2-proxy:
 
 s3sealedsecret:
   enabled: true
+
 bitnamisecret:
   enabled: true
 

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -55,17 +55,6 @@ argo-workflows:
 
     workflowDefaults:
       spec:
-        podSpecPatch: |
-          containers:
-            - name: main
-              resources:
-                requests:
-                  memory: "2Gi"
-                  cpu: "500m"
-                limits:
-                  memory: "4Gi"
-                  cpu: "1000m"
-
         serviceAccountName: argo-workflow
 
         ttlStrategy:


### PR DESCRIPTION
This PR standardises CPU and memory requests/limits across the Argo Workflows Helm chart to  ensure consistent resource allocation for controller, server, and workflow execution pods.

-Updated controller resources to:   requests: 500m CPU / 2Gi memory
                                                       limits: 1 CPU / 4Gi memory
-Updated server resources to:   requests: 1 CPU / 1Gi memory
                                                   limits: 2 CPU / 2Gi memory
-Added/updated workflowDefaults.spec.podSpecPatch to enforce workflow pod resources:
                                                  requests: 500m CPU / 2Gi memory
                                                  limits: 1 CPU / 4Gi memory
-Applies to:     new workflow executions only
                      No changes required to existing workflows

Verification:
Verified via helm template rendering that workflowDefaults.spec.podSpecPatch applies CPU and memory requests/limits to the workflow main container. Confirmed in rendered output:
workflowDefaults.spec.podSpecPatch → containers.main.resources

Confirmed using Helm-rendered manifests and grep validation.
grep -n "podSpecPatch" rendered.yaml
grep -n "2Gi" rendered.yaml
grep -n "500m" rendered.yaml




      