### PR TITLE
feat(charts): add stomp event server

### DIFF
--- a/charts/events/Chart.lock
+++ b/charts/events/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: metacontroller-helm
   repository: oci://ghcr.io/metacontroller
   version: 4.15.0
-digest: sha256:cce917621c4901d4b789c0610b11ae33dfb2d5b20483671a755871ed569b3e6d
-generated: "2026-04-28T14:20:52.776857429+01:00"
+digest: sha256:cebfe83f6391e360563587099a03ef62a058fddb81fa5cff42e2000ce1721a65
+generated: "2026-05-28T15:44:00.60302199+01:00"

--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -3,11 +3,10 @@ name: events
 description: Data Analysis event triggering
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
 dependencies:
   - name: argo-events
-    alias: argoevents
     repository: https://argoproj.github.io/argo-helm
     version: 2.4.9
     condition: argo-events.enabled

--- a/charts/events/generic-servers/stomp-server.py
+++ b/charts/events/generic-servers/stomp-server.py
@@ -1,0 +1,108 @@
+import generic_pb2
+import generic_pb2_grpc
+import stomp
+import grpc
+import logging
+import stomp.utils
+import queue
+import json
+import os
+from concurrent import futures
+from pydantic import BaseModel, ConfigDict
+from typing import Literal
+
+
+class EventSourceConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    user: str
+    password: str
+    host: str
+    port: int
+    destination: str
+    ack: Literal["auto", "client", "client-individual"] = "auto"
+
+def parse_config(config: bytes) -> EventSourceConfig | None:
+    try:
+        decoded_confid = config.decode()
+        config_entries = decoded_confid.strip().split("\n")
+        config_dict = dict(entry.split(": ") for entry in config_entries)
+        return EventSourceConfig.model_validate(config_dict)
+    except:
+        logging.error("Unable to parse EventSource config")
+        return
+
+
+def _build_event(payload: str) -> generic_pb2.Event:
+    return generic_pb2.Event(name="workflow-trigger", payload=payload.encode())
+
+
+class _StompListener(stomp.ConnectionListener):
+    def __init__(self, q):
+        self.q = q
+
+    def on_connected(self, frame: stomp.utils.Frame) -> None:
+        logging.info("Connected to STOMP broker")
+
+    def on_disconnected(self) -> None:
+        logging.warning("Disconnected from STOMP broker")
+
+    def on_error(self, frame: stomp.utils.Frame) -> None:
+        logging.error("Broker error: %s", frame.body)
+
+    def on_message(self, frame: stomp.utils.Frame) -> None:
+        logging.debug("Message received: %s", frame.body)
+        if isinstance(frame.body, str):
+            messageJson = json.loads(frame.body)
+            if messageJson.get("name") == "start":
+                self.q.put(frame.body)
+
+    def on_heartbeat(self):
+        logging.debug("Hearbeat received")
+
+class StompEventServicer(generic_pb2_grpc.EventingServicer):
+    def StartEventSource(self, request, context):
+        event_queue = queue.SimpleQueue()
+        config = parse_config(request.config)
+
+        if not config:
+            logging.error("No config supplied")
+            return
+        logging.debug("Using config: %s", config)
+        conn = stomp.Connection([(config.host, config.port)], heartbeats=(10000, 10000))
+        conn.set_listener("", _StompListener(event_queue))
+        conn.connect(
+            login=config.user,
+            passcode=config.password,
+            wait=True,
+            headers={"host": "/"},
+        )
+        conn.subscribe(
+            destination=config.destination, id="workflows-trigger", ack=config.ack
+        )
+
+        while True:
+            try:
+                msg = event_queue.get(timeout=1)
+            except queue.Empty:
+                continue
+
+            yield _build_event(msg)
+
+
+def serve():
+    port = "50051"
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    generic_pb2_grpc.add_EventingServicer_to_server(StompEventServicer(), server)
+    server.add_insecure_port("[::]:" + port)
+    server.start()
+    logging.info("Server started, listening on " + port)
+    server.wait_for_termination()
+
+
+if __name__ == "__main__":
+    LOG_LEVEL = os.environ.get("LOGLEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=LOG_LEVEL, format="%(asctime)s %(levelname)s %(name)s - %(message)s"
+    )
+    serve()

--- a/charts/events/hooks/sync.py
+++ b/charts/events/hooks/sync.py
@@ -65,7 +65,7 @@ class Controller(BaseHTTPRequestHandler):
       sensorParams = [{
           "src": {
             "dependencyName": name, 
-            "dataKey": "body.user_namespace"
+            "dataKey": "body.doc.instrument_session"
           },
           "dest": "metadata.namespace"
         }]

--- a/charts/events/templates/event-sources.yaml
+++ b/charts/events/templates/event-sources.yaml
@@ -17,4 +17,23 @@ spec:
     {{- $eventSource.webhook | toYaml | nindent 6 }}
   {{- end }}
   {{- end }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: waffle-generic
+  labels:
+    workflows.diamond.ac.uk/beamline: i15-1
+spec:
+  generic:
+    waffle-example:
+      insecure: true
+      jsonBody: true
+      url: "stomp-service.events.svc:80"
+      config: |
+        user: guest
+        password: guest
+        host: i15-1-rabbitmq-daq.diamond.ac.uk
+        port: 61613
+        destination: /queue/public.worker.event.workflows
 {{- end }}

--- a/charts/events/templates/example-trigger.yaml
+++ b/charts/events/templates/example-trigger.yaml
@@ -22,4 +22,20 @@ spec:
         messagePath: body.parameters.tiff
       - name: png
         messagePath: body.parameters.png
+---
+apiVersion: workflows.diamond.ac.uk/v1alpha1
+kind: Trigger
+metadata:
+  name: waffle-trigger
+  labels:
+    workflows.diamond.ac.uk/source: generic
+    workflows.diamond.ac.uk/beamline: i15-1
+spec:
+  enabled: true
+  eventName: waffle-example
+  workflow:
+    template: echo-workflow-template
+    parameters:
+      - name: message
+        messagePath: body.name
 {{- end }}

--- a/charts/events/templates/stomp-server.yaml
+++ b/charts/events/templates/stomp-server.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.genericServers.stomp.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: stomp-service
+spec:
+  selector:
+    app.kubernetes.io/name: stomp-server
+  ports:
+    - name: stomp-server
+      protocol: TCP
+      port: 80
+      targetPort: stomp-server
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stomp-server
+data: {{- (.Files.Glob "generic-servers/stomp-server.py").AsConfig | nindent 2 }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: generic-proto
+data:
+  generic.proto: |
+    syntax = "proto3";
+    package generic;
+
+    service Eventing {
+        rpc StartEventSource(EventSource) returns (stream Event);
+    }
+
+    message EventSource {
+        // The event source name.
+        string name = 1;
+        // The event source configuration value.
+        bytes config = 2;
+    }
+
+    message Event {
+        // The event source name.
+        string name = 1;
+        // The event payload.
+        bytes payload = 2;
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stomp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stomp-server
+  template:
+    metadata:
+      labels:
+        app: stomp-server
+        app.kubernetes.io/name: stomp-server
+    spec:
+      containers:
+        - name: server
+          image: python:3.12-slim
+          ports:
+            - name: stomp-server
+              containerPort: 50051
+          workingDir: /server
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              cp /scripts/stomp-server.py .
+              pip install stomp.py pydantic grpcio-tools --disable-pip-version-check --root-user-action=ignore
+              python -m grpc_tools.protoc -I /protos --python_out=. --pyi_out=. --grpc_python_out=. /protos/generic.proto && 
+              python stomp-server.py
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: LOGLEVEL
+              value: {{ .Values.genericServers.stomp.logLevel }}
+          volumeMounts:
+            - name: script-volume
+              mountPath: /scripts
+            - name: generic-proto-volume
+              mountPath: /protos
+            - name: server-volume
+              mountPath: /server
+      volumes:
+        - name: script-volume
+          configMap:
+            name: stomp-server
+        - name: generic-proto-volume
+          configMap:
+            name: generic-proto
+        - name: server-volume
+          emptyDir: {}
+{{- end }}

--- a/charts/events/values.yaml
+++ b/charts/events/values.yaml
@@ -1,22 +1,16 @@
 argo-events:
   enabled: true
   controller:
-    replicas: 1
-    pdb:
-      minAvailable: 1
-    serviceAccount:
-      name: argo-events-sa
-    volumeMounts:
-      - name: controller-config-volume
-        mountPath: /etc/argo-events
-    volumes:
-      - name: controller-config-volume
-        configMap:
-          name: argo-events-controller-config
-  webhook:
-    enabled: true
-    serviceAccount:
-      name: argo-events-webhook-sa
+    containerSecurityContext:
+      runAsUser: 36055
+      runAsGroup: 36055
+    resources:
+      requests:
+        cpu: 100m
+        memory: 2Gi
+      limits:
+        cpu: 1
+        memory: 4Gi
 
 eventBuses:
   - name: default
@@ -24,8 +18,10 @@ eventBuses:
     resources:
       requests:
         cpu: 10m
+        memory: 1Gi
       limits:
         cpu: 100m
+        memory: 4Gi
 
 eventSources:
   - name: example
@@ -40,6 +36,11 @@ eventSources:
         endpoint: /example
         # HTTP request method to allow. In this case, only POST requests are accepted
         method: POST
+
+genericServers:
+  stomp:
+    enabled: true
+    logLevel: INFO
 
 metacontroller:
   enabled: true


### PR DESCRIPTION
The main addition in this PR is a '[generic' EventSource](https://argoproj.github.io/argo-events/eventsources/generic/) for handling STOMP messages. A generic EventSource requires a server that implements the gRPC contract at the previous link. It is set up using the `config` field in the EventSource - this can contain anything, provided the server can parse it. 

My server takes in the stomp connection config, creates the connection and then adds any received 'scan start' messages to a queue that gets turned into Events.  Only the 'start' messages contain the visitId, so for now only those are being processed. Eventually, subsequent messages will need to be matched to their scan start message by the scan uid. I also intend to move the filtering logic [into the EventSource](https://argoproj.github.io/argo-events/eventsources/filtering/) itself in future, but I haven't had a chance to test that yet. 

I have put the server code in a ConfigMap that gets ran in a plain python container - this could be replaced by a custom server container down the road. It also remains to be seen whether or not this server can be shared between multiple EventSources