### PR TITLE
feat(charts): allow auto workflows to set own posixuid

### DIFF
--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -3,7 +3,7 @@ name: events
 description: Data Analysis event triggering
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 dependencies:
   - name: argo-events

--- a/charts/events/hooks/sync.py
+++ b/charts/events/hooks/sync.py
@@ -46,7 +46,9 @@ class Controller(BaseHTTPRequestHandler):
     dependencies = []
     sourceTriggers: dict[str, dict] = related.get("Trigger.workflows.diamond.ac.uk/v1alpha1", {})
     eventSourceName: str | None = parent.get("metadata", {}).get("name")
-    beamline: str | None = parent.get("metadata", {}).get("labels", {}).get("workflows.diamond.ac.uk/beamline")
+    labels: dict = parent.get("metadata", {}).get("labels", {})
+    beamline: str | None = labels.get("workflows.diamond.ac.uk/beamline")
+    uid: str | None = labels.get("workflows.diamond.ac.uk/machine-uid")
 
     for dlsTrigger in sourceTriggers.values():
       spec: dict = dlsTrigger.get("spec", {})
@@ -94,6 +96,9 @@ class Controller(BaseHTTPRequestHandler):
                 "kind": "Workflow",
                 "metadata": {
                   "generateName": f"{template}-event-",
+                  "labels": {
+                      "workflows.diamond.ac.uk/machine-uid": uid,
+                    }
                 },
                 "spec": {
                   "serviceAccountName": "argo-workflow",
@@ -104,11 +109,6 @@ class Controller(BaseHTTPRequestHandler):
                   "arguments": {
                     "parameters": templateArgs
                   },
-                  # "workflowMetadata": {
-                  #   "labels": {
-                  #     "workflows.diamond.ac.uk/creator-posix-uid": "36055"
-                  #   }
-                  # }     
                 },
               }
             }
@@ -120,7 +120,7 @@ class Controller(BaseHTTPRequestHandler):
       "apiVersion": "argoproj.io/v1alpha1",
       "kind": "Sensor",
       "metadata": {
-        "name": f"{beamline}-{eventSourceName}-sensor"
+        "name": f"{beamline}-{eventSourceName}"
       },
       "spec": {
         "template":

--- a/charts/events/templates/event-sources.yaml
+++ b/charts/events/templates/event-sources.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ $eventSource.name }}
   labels:
     workflows.diamond.ac.uk/beamline: {{ $eventSource.beamline }}
+    workflows.diamond.ac.uk/machine-uid: "36055"
 spec:
   service:
     ports:
@@ -24,6 +25,7 @@ metadata:
   name: waffle-generic
   labels:
     workflows.diamond.ac.uk/beamline: i15-1
+    workflows.diamond.ac.uk/machine-uid: "36242"
 spec:
   generic:
     waffle-example:

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: workflows
 description: Data Analysis workflow orchestration
 type: application
-version: 0.13.48
+version: 0.13.49
 dependencies:
   - name: argo-workflows
     repository: https://argoproj.github.io/argo-helm

--- a/charts/workflows/templates/workflow-label-clusterpolicy.yaml
+++ b/charts/workflows/templates/workflow-label-clusterpolicy.yaml
@@ -13,6 +13,10 @@ spec:
             - argoproj.io/*/Workflow
           operations:
             - CREATE
+      context:
+        - name: machineuid
+          variable:
+            jmesPath: request.object.metadata.labels."workflows.diamond.ac.uk/machine-uid" || ""
       mutate:
         patchStrategicMerge:
           metadata:
@@ -20,5 +24,5 @@ spec:
               {{- with .Values.uid }}
               workflows.diamond.ac.uk/creator-posix-uid: '{{ . }}'
               {{- else }}
-              workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra | "workflows.diamond.ac.uk/posixuid" | [0] }}` }}'
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra."workflows.diamond.ac.uk/posixuid"[0] || machineuid }}` }}'
               {{- end }}


### PR DESCRIPTION
[AP-1110](https://jira.diamond.ac.uk/browse/AP-1110)

I had to remove the pipe expressions from the JMESPath in the policy - they don't seem to work with the || operator. Possibly a kyverno bug, as they seem to behave as one would expect in the JMESPath tutorial/playground.

If `identity-mapper` changes related to [AP-1140](https://jira.diamond.ac.uk/browse/AP-1140) are merged in before this, then that policy will need updating instead in a similar way to how `workflow-label-clusterpolicy` is here e.g. 
```
context:
     - name: posixUidString
       variable:
         value: "{{`{{ request.userInfo.extra.\"workflows.diamond.ac.uk/posixuid\"[0] || request.object.metadata.labels.\"workflows.diamond.ac.uk/machine-uid\" }}`}}"
```