### PR TITLE
Tbt/auth minor fixes

### DIFF
--- a/backend/auth-daemon/README.md
+++ b/backend/auth-daemon/README.md
@@ -5,17 +5,15 @@ Sidecar HTTP proxy that injects valid OIDC access tokens into GraphQL requests m
 ## Usage
 
 ```sh
-WORKFLOWS_AUTH_DAEMON_CONFIG=config.yaml \
-WORKFLOWS_AUTH_DAEMON_SUBJECT=<oidc-subject> \
-cargo run
+WORKFLOWS_AUTH_DAEMON_CONFIG=config.yaml cargo run -- serve
 ```
 
-The subject identifies the user whose stored refresh token to load from the database.
+The daemon resolves the subject (the user whose stored refresh token to load) at startup by inspecting its own pod: it reads its namespace from the service-account mount and its pod name from `/etc/hostname`, looks up that pod's `workflows.argoproj.io/workflow` label to find the owning workflow, then reads that workflow's `workflows.argoproj.io/creator` label — all via the Kubernetes API. No auth-specific environment variables are required. Its service account needs `get` access to `pods` and `workflows.argoproj.io` in its namespace.
 
 ## Endpoints
 
 | Path | Method | Description |
 |------|--------|-------------|
-| `/` | `POST` | Authenticated proxy to the configured GraphQL endpoint |
+| `/` | any | Authenticated proxy to the configured GraphQL endpoint |
 | `/healthz` | `GET` | Health check (returns 202) |
 

--- a/backend/oidc-bff/src/main.rs
+++ b/backend/oidc-bff/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
 
     auth_core::database::migrate_database(&appstate.database_connection).await?;
 
-    auth_core::rustls::crypto::ring::default_provider()
+    auth_core::rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("Failed to install rust TLS cryptography");
 


### PR DESCRIPTION
Minor fixes to auth after adjusting auth-daemon to run the workflows of workflows pattern

Re the _default provider_: This is just to use the crate that was explicitly set in auth-core for auth-daemon to work. 