### PR TITLE
feat(charts): rework machine uid admission policy

### DIFF
--- a/charts/events/Chart.yaml
+++ b/charts/events/Chart.yaml
@@ -3,7 +3,7 @@ name: events
 description: Data Analysis event triggering
 type: application
 
-version: 0.2.4
+version: 0.2.5
 
 dependencies:
   - name: argo-events

--- a/charts/events/hooks/sync.py
+++ b/charts/events/hooks/sync.py
@@ -46,7 +46,9 @@ class Controller(BaseHTTPRequestHandler):
     dependencies = []
     sourceTriggers: dict[str, dict] = related.get("Trigger.workflows.diamond.ac.uk/v1alpha1", {})
     eventSourceName: str | None = parent.get("metadata", {}).get("name")
-    beamline: str | None = parent.get("metadata", {}).get("labels", {}).get("workflows.diamond.ac.uk/beamline")
+    labels: dict = parent.get("metadata", {}).get("labels", {})
+    beamline: str | None = labels.get("workflows.diamond.ac.uk/beamline")
+    uid: str | None = labels.get("workflows.diamond.ac.uk/machine-uid")
 
     for dlsTrigger in sourceTriggers.values():
       spec: dict = dlsTrigger.get("spec", {})
@@ -94,6 +96,9 @@ class Controller(BaseHTTPRequestHandler):
                 "kind": "Workflow",
                 "metadata": {
                   "generateName": f"{template}-event-",
+                  "labels": {
+                      "workflows.diamond.ac.uk/machine-uid": uid,
+                    }
                 },
                 "spec": {
                   "serviceAccountName": "argo-workflow",
@@ -104,11 +109,6 @@ class Controller(BaseHTTPRequestHandler):
                   "arguments": {
                     "parameters": templateArgs
                   },
-                  # "workflowMetadata": {
-                  #   "labels": {
-                  #     "workflows.diamond.ac.uk/creator-posix-uid": "36055"
-                  #   }
-                  # }     
                 },
               }
             }
@@ -120,7 +120,7 @@ class Controller(BaseHTTPRequestHandler):
       "apiVersion": "argoproj.io/v1alpha1",
       "kind": "Sensor",
       "metadata": {
-        "name": f"{beamline}-{eventSourceName}-sensor"
+        "name": f"{beamline}-{eventSourceName}"
       },
       "spec": {
         "template":

--- a/charts/events/templates/event-sources.yaml
+++ b/charts/events/templates/event-sources.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ $eventSource.name }}
   labels:
     workflows.diamond.ac.uk/beamline: {{ $eventSource.beamline }}
+    workflows.diamond.ac.uk/machine-uid: "36055"
 spec:
   service:
     ports:
@@ -24,6 +25,7 @@ metadata:
   name: waffle-generic
   labels:
     workflows.diamond.ac.uk/beamline: i15-1
+    workflows.diamond.ac.uk/machine-uid: "36242"
 spec:
   generic:
     waffle-example:

--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: workflows
 description: Data Analysis workflow orchestration
 type: application
-version: 0.13.50
+version: 0.13.51
 dependencies:
   - name: argo-workflows
     repository: https://argoproj.github.io/argo-helm

--- a/charts/workflows/staging-values.yaml
+++ b/charts/workflows/staging-values.yaml
@@ -38,3 +38,5 @@ postgresql-ha:
     size: 10Gi
   postgresql:
     podAntiAffinityPreset: soft
+
+allowMachineUid: true

--- a/charts/workflows/templates/workflow-label-clusterpolicy.yaml
+++ b/charts/workflows/templates/workflow-label-clusterpolicy.yaml
@@ -13,12 +13,19 @@ spec:
             - argoproj.io/*/Workflow
           operations:
             - CREATE
+      context:
+        - name: machineuid
+          variable:
+            jmesPath: request.object.metadata.labels."workflows.diamond.ac.uk/machine-uid" || ""
+            default: ""
       mutate:
         patchStrategicMerge:
           metadata:
             labels:
-              {{- with .Values.uid }}
-              workflows.diamond.ac.uk/creator-posix-uid: '{{ . }}'
+              {{- if .Values.uid }}
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ .Values.uid }}'
+              {{- else if .Values.allowMachineUid }}
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra."workflows.diamond.ac.uk/posixuid"[0] || machineuid }}` }}'
               {{- else }}
-              workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra | "workflows.diamond.ac.uk/posixuid" | [0] }}` }}'
+              workflows.diamond.ac.uk/creator-posix-uid: '{{ `{{ request.userInfo.extra."workflows.diamond.ac.uk/posixuid"[0] }}` }}'
               {{- end }}

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -273,3 +273,5 @@ bitnamisecret:
 
 s3mock:
   enabled: false
+
+allowMachineUid: false


### PR DESCRIPTION
Largely the same as #1364 but uses a default value for the `machineuid` variable in addition to the non-existence path check. Also, I'm only turning this on for staging this time.
I've tested the following cases:

- [A manually submitted workflow](https://staging.workflows.diamond.ac.uk/workflows/mg36964-1/echo-workflow-template-9nxt5)
- [A manually submitted workflow with the machinuid label manually applied](https://staging.workflows.diamond.ac.uk/workflows/mg36964-1/test-machineuid-cgl6v)
- [An automated workflow](https://staging.workflows.diamond.ac.uk/workflows/mg36964-1/example-template-event-s7sjz)