### PR TITLE
fix(graph-proxy): subscriptions enforces authentication with AuthGuard

### DIFF
--- a/backend/graph-proxy/src/graphql/subscription.rs
+++ b/backend/graph-proxy/src/graphql/subscription.rs
@@ -1,7 +1,7 @@
+use crate::graphql::AuthGuard;
 use argo_workflows_openapi::IoArgoprojWorkflowV1alpha1WorkflowWatchEvent;
 use async_graphql::{Context, SimpleObject, Subscription};
 use async_stream::stream;
-use axum_extra::headers::{authorization::Bearer, Authorization};
 use eventsource_stream::Eventsource;
 use futures_util::{Stream, StreamExt};
 use serde::Deserialize;
@@ -12,6 +12,7 @@ use crate::{
         workflows::{Workflow, WorkflowParsingError},
         VisitInput,
     },
+    validate_token::ValidatedAuthToken,
     ArgoServerUrl,
 };
 
@@ -56,13 +57,14 @@ struct WatchEvent {
 
 /// Get authentication token
 fn get_auth_token(ctx: &Context<'_>) -> anyhow::Result<String> {
-    ctx.data_unchecked::<Option<Authorization<Bearer>>>()
+    let auth_token = ctx.data_unchecked::<ValidatedAuthToken>().as_token();
+    auth_token
         .as_ref()
         .map(|auth| auth.token().to_string())
         .ok_or_else(|| WorkflowParsingError::MissingAuthToken.into())
 }
 
-#[Subscription]
+#[Subscription(guard = "AuthGuard")]
 impl WorkflowsSubscription {
     /// Processing to subscribe to logs for a single pod of a workflow
     async fn logs(
@@ -212,4 +214,176 @@ struct StreamError {
     message: String,
 }
 
-// TODO! Write tests for this
+#[cfg(test)]
+mod tests {
+
+    use std::{env, fs, path::PathBuf};
+
+    use async_graphql::Request;
+    use axum_extra::headers::Authorization;
+    use futures_util::StreamExt;
+    use mockito::Matcher;
+    use rstest::rstest;
+    use serde_json::{json, Value};
+    use url::Url;
+
+    use crate::graphql::Visit;
+    use crate::ArgoServerUrl;
+
+    use crate::graphql::root_schema_builder;
+    use crate::validate_token::ValidatedAuthToken;
+
+    fn test_token() -> ValidatedAuthToken {
+        let token = Authorization::bearer("test-token").expect("token always valid");
+        ValidatedAuthToken::Valid(token)
+    }
+
+    #[tokio::test]
+    async fn single_workflow_subscription_returns_first_event() {
+        let workflow_name = "numpy-benchmark-wdkwj";
+        let visit = Visit {
+            proposal_code: "mg".to_string(),
+            proposal_number: 36964,
+            number: 1,
+        };
+
+        let mut workflow_file_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        workflow_file_path.push("test-assets");
+        workflow_file_path.push("get-workflow-wdkwj.json");
+
+        let workflow_json =
+            fs::read_to_string(&workflow_file_path).expect("failed to read workflow test asset");
+
+        let workflow_value: Value =
+            serde_json::from_str(&workflow_json).expect("workflow fixture is not valid JSON");
+
+        let event_payload = json!({
+            "result": {
+                "object": workflow_value
+            },
+            "error": null
+        });
+
+        let sse_body = format!(
+            "data: {}\n\n",
+            serde_json::to_string(&event_payload).expect("failed to serialize SSE payload")
+        );
+
+        let mut server = mockito::Server::new_async().await;
+        let path = format!("/api/v1/workflow-events/{visit}");
+        let workflow_events_endpoint = server
+            .mock("GET", path.as_str())
+            .match_query(Matcher::UrlEncoded(
+                "listOptions.fieldSelector".into(),
+                format!("metadata.name={workflow_name},metadata.namespace={visit}"),
+            ))
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(sse_body)
+            .create_async()
+            .await;
+
+        let argo_server_url = Url::parse(&server.url()).unwrap();
+
+        let schema = root_schema_builder()
+            .data(ArgoServerUrl(argo_server_url))
+            .data(test_token())
+            .finish();
+
+        let request = Request::new(format!(
+            r#"
+        subscription {{
+            workflow(
+                name: "{}",
+                visit: {{ proposalCode: "{}", proposalNumber: {}, number: {} }}
+            ) {{
+                name
+            }}
+        }}
+        "#,
+            workflow_name, visit.proposal_code, visit.proposal_number, visit.number
+        ));
+
+        let mut response_stream = schema.execute_stream(request);
+
+        let first_response = response_stream
+            .next()
+            .await
+            .expect("subscription stream ended before first response");
+
+        assert!(
+            first_response.errors.is_empty(),
+            "unexpected GraphQL errors: {:?}",
+            first_response.errors
+        );
+
+        let expected_data = json!({
+            "workflow": {
+                "name": workflow_name
+            }
+        });
+
+        assert_eq!(
+            first_response
+                .data
+                .into_json()
+                .expect("invalid response json"),
+            expected_data
+        );
+
+        workflow_events_endpoint.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[rstest]
+    #[case(ValidatedAuthToken::Missing)]
+    #[case(ValidatedAuthToken::Invalid)]
+    #[case(ValidatedAuthToken::Failed("reason".to_string()))]
+    async fn unauthenticated_subscription_returns_null(#[case] auth_token: ValidatedAuthToken) {
+        use crate::graphql::auth_guard::AuthErrorCode;
+
+        let schema = root_schema_builder().data(auth_token).finish();
+
+        let request = Request::new(
+            r#"
+        subscription {
+            workflow(
+                name: "workflowName",
+                visit: { proposalCode: "xy", proposalNumber: 1234, number: 5678 }
+            ) {
+                name
+            }
+        }
+    "#,
+        );
+
+        let mut response_stream = schema.execute_stream(request);
+
+        let first_response = response_stream
+            .next()
+            .await
+            .expect("subscription stream ended before first response");
+
+        let expected_data = json!(null);
+        assert_eq!(
+            first_response
+                .data
+                .into_json()
+                .expect("invalid response json"),
+            expected_data
+        );
+
+        let error_code = first_response.errors[0]
+            .extensions
+            .as_ref()
+            .expect("missing extensions")
+            .get("code")
+            .expect("missing code")
+            .clone()
+            .into_json()
+            .expect("invalid json");
+
+        let expected_value = json!(AuthErrorCode::Unauthenticated.to_string());
+        assert_eq!(error_code, expected_value);
+    }
+}

--- a/backend/graph-proxy/src/graphql/subscription_integration.rs
+++ b/backend/graph-proxy/src/graphql/subscription_integration.rs
@@ -14,7 +14,7 @@
 // accessible inside the graph functions - after upgrading
 // requests to websocket, which is not natively supported.
 
-use std::{convert::Infallible, future::Future, str::FromStr, time::Duration};
+use std::{convert::Infallible, future::Future, str::FromStr, sync::Arc, time::Duration};
 
 use async_graphql::{
     futures_util::task::{Context, Poll},
@@ -47,7 +47,10 @@ use futures_util::{
 use opentelemetry::KeyValue;
 use tower_service::Service;
 
-use crate::metrics::MetricsState;
+use crate::{
+    metrics::MetricsState,
+    validate_token::{TokenValidator, ValidationMethod},
+};
 
 /// A GraphQL protocol extractor.
 ///
@@ -80,6 +83,7 @@ where
 pub struct GraphQLSubscription<E> {
     executor: E,
     metrics_state: MetricsState,
+    token_validator: Arc<TokenValidator>,
 }
 
 impl<E> Clone for GraphQLSubscription<E>
@@ -90,6 +94,7 @@ where
         Self {
             executor: self.executor.clone(),
             metrics_state: self.metrics_state.clone(),
+            token_validator: self.token_validator.clone(),
         }
     }
 }
@@ -99,10 +104,15 @@ where
     E: Executor,
 {
     /// Create a GraphQL subscription service.
-    pub fn new(executor: E, metrics_state: MetricsState) -> Self {
+    pub fn new(
+        executor: E,
+        metrics_state: MetricsState,
+        token_validator: Arc<TokenValidator>,
+    ) -> Self {
         Self {
             executor,
             metrics_state,
+            token_validator,
         }
     }
 }
@@ -123,9 +133,11 @@ where
     fn call(&mut self, req: Request<B>) -> Self::Future {
         let executor = self.executor.clone();
         let metrics = self.metrics_state.clone();
+        let token_validator = self.token_validator.clone();
 
         Box::pin(async move {
             let metrics = metrics;
+            let token_validator = token_validator.clone();
             let (mut parts, _body) = req.into_parts();
 
             let protocol = match GraphQLProtocol::from_request_parts(&mut parts, &()).await {
@@ -153,7 +165,7 @@ where
                 .protocols(ALL_WEBSOCKET_PROTOCOLS)
                 .on_upgrade(move |stream| {
                     let websocket = GraphQLWebSocket::new(stream, executor, protocol)
-                        .on_connection_init(|value: serde_json::Value| async move {
+                        .on_connection_init(move |value: serde_json::Value| async move {
                             let conn_init_auth_header = value
                                 .get("Authorization")
                                 .and_then(|value| value.as_str())
@@ -173,7 +185,10 @@ where
                             match auth_header {
                                 Ok(header) => {
                                     let mut data = Data::default();
-                                    data.insert(Some(header));
+                                    let validated_token = token_validator
+                                        .validate_token(Some(header), ValidationMethod::Jwt)
+                                        .await;
+                                    data.insert(validated_token);
                                     Ok(data)
                                 }
                                 Err(_e) => {
@@ -375,10 +390,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{metrics::noop::NoopMeterProvider, metrics::Metrics};
+    use crate::{
+        metrics::{noop::NoopMeterProvider, Metrics},
+        test_oidc_server::TestOidcServer,
+        validate_token::ValidatedAuthToken,
+    };
     use async_graphql::{Context, EmptyMutation, Object, Schema, Subscription};
-    use axum::{routing::get_service, Router};
-    use axum_extra::headers::{authorization::Bearer, Authorization};
+    use axum::{http::Uri, routing::get_service, Router};
+    use axum_extra::headers::HeaderMapExt;
     use futures_util::Stream;
     use graphql_ws_client::graphql::StreamingOperation;
     use serde::{Deserialize, Serialize};
@@ -405,8 +424,8 @@ mod tests {
         /// Token Data provided by async_graphql::Context
         async fn token(&self, ctx: &Context<'_>) -> impl Stream<Item = String> + '_ {
             let token_str = ctx
-                .data_opt::<Option<Authorization<Bearer>>>()
-                .and_then(|opt| opt.as_ref())
+                .data_opt::<ValidatedAuthToken>()
+                .and_then(|auth| auth.as_token())
                 .map(|auth| auth.token().to_string())
                 .unwrap_or_else(|| "No token".to_string());
 
@@ -433,7 +452,18 @@ mod tests {
         }
     }
 
-    async fn start_echo_token_server() -> (String, tokio::task::JoinSet<()>) {
+    async fn start_echo_token_server(
+    ) -> anyhow::Result<(String, tokio::task::JoinSet<()>, TestOidcServer)> {
+        let oidc_server = TestOidcServer::new().await?;
+
+        let token_validator = TokenValidator::new(
+            &oidc_server.issuer_url.parse::<Uri>()?,
+            "test-client",
+            Some("test-secret".to_string()),
+            vec!["workflows-cluster"],
+        )
+        .await?;
+
         let schema = Schema::build(QueryRoot, EmptyMutation, EchoTokenSubscriptionRoot).finish();
 
         let router = Router::new()
@@ -442,6 +472,7 @@ mod tests {
                 get_service(GraphQLSubscription::new(
                     schema.clone(),
                     MetricsState::new(Metrics::new(&NoopMeterProvider::new())),
+                    Arc::new(token_validator),
                 )),
             )
             .with_state(schema.clone());
@@ -457,20 +488,24 @@ mod tests {
         job.spawn(async move {
             server.await.expect("server error");
         });
-        (address, job)
+        Ok((address, job, oidc_server))
     }
 
     #[tokio::test]
     async fn subscription_token_is_read_from_http_header() -> anyhow::Result<()> {
-        let (server_address, _server_guard) = start_echo_token_server().await;
+        if std::env::var("WORKFLOWS_DEV_CONTAINER").is_ok() {
+            eprintln!("Skipping test: test containers don't work inside VSCode dev container");
+            return Ok(());
+        }
 
-        let token = "http_header_token_value";
+        let (server_address, _server_guard, oidc_server) = start_echo_token_server().await?;
+
+        let access_token = oidc_server.access_token().await?;
+
+        let expected_token = access_token.token().to_string();
 
         let mut req = server_address.into_client_request()?;
-        req.headers_mut().insert(
-            http::header::AUTHORIZATION,
-            http::HeaderValue::from_str(&format!("Bearer {token}"))?,
-        );
+        req.headers_mut().typed_insert(access_token);
         req.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,
             http::HeaderValue::from_static("graphql-transport-ws"),
@@ -488,18 +523,25 @@ mod tests {
         assert!(response.errors.unwrap_or_default().is_empty());
         assert_eq!(
             response.data.expect("no data"),
-            serde_json::json!({"token": token}),
+            serde_json::json!({"token": expected_token}),
             "http header token is used for auth"
         );
-
+        oidc_server.stop().await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn subscription_token_is_read_from_connection_init_payload() -> anyhow::Result<()> {
-        let (server_address, _server_guard) = start_echo_token_server().await;
+        if std::env::var("WORKFLOWS_DEV_CONTAINER").is_ok() {
+            eprintln!("Skipping test: test containers don't work inside VSCode dev container");
+            return Ok(());
+        }
 
-        let token = "connection_init_token_value";
+        let (server_address, _server_guard, oidc_server) = start_echo_token_server().await?;
+
+        let access_token = oidc_server.access_token().await?;
+
+        let expected_token = access_token.token().to_string();
 
         let mut req = server_address.into_client_request()?;
         req.headers_mut().insert(
@@ -510,7 +552,7 @@ mod tests {
         let (ws, _resp) = tokio_tungstenite::connect_async(req).await?;
 
         let client = graphql_ws_client::Client::build(ws).payload(json!({
-            "Authorization": format!("Bearer {token}"),
+            "Authorization": format!("Bearer {}", access_token.token()),
         }))?;
         let mut subscription = client
             .subscribe(StreamingOperation::<TestGraphQlTokenQuery>::new(()))
@@ -520,16 +562,21 @@ mod tests {
         assert!(response.errors.unwrap_or_default().is_empty());
         assert_eq!(
             response.data.expect("no data"),
-            serde_json::json!({"token": token}),
+            serde_json::json!({"token": expected_token}),
             "connection_init token is used for auth"
         );
-
+        oidc_server.stop().await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn subscription_returns_error_if_no_token() -> anyhow::Result<()> {
-        let (server_address, _server_guard) = start_echo_token_server().await;
+        if std::env::var("WORKFLOWS_DEV_CONTAINER").is_ok() {
+            eprintln!("Skipping test: test containers don't work inside VSCode dev container");
+            return Ok(());
+        }
+
+        let (server_address, _server_guard, oidc_server) = start_echo_token_server().await?;
 
         let mut req = server_address.into_client_request()?;
         req.headers_mut().insert(
@@ -551,7 +598,7 @@ mod tests {
             ),
             "subscriptions require an auth token in either http header or connection_init frame"
         );
-
+        oidc_server.stop().await?;
         Ok(())
     }
 }

--- a/backend/graph-proxy/src/main.rs
+++ b/backend/graph-proxy/src/main.rs
@@ -14,6 +14,9 @@ mod metrics;
 /// Validate Bearer tokens
 mod validate_token;
 
+#[cfg(test)]
+mod test_oidc_server;
+
 use crate::{
     graphql::subscription_integration::GraphQLSubscription,
     metrics::{Metrics, MetricsState},
@@ -225,7 +228,7 @@ async fn setup_router(
             .with_state(RouterState {
                 schema: schema.clone(),
                 metrics_state: metrics_state.clone(),
-                token_validator,
+                token_validator: token_validator.clone(),
             }),
         )
         .route_service(
@@ -233,6 +236,7 @@ async fn setup_router(
             get_service(GraphQLSubscription::new(
                 schema.clone(),
                 metrics_state.clone(),
+                Arc::new(token_validator),
             )),
         )
         .with_state(schema.clone())

--- a/backend/graph-proxy/src/test_oidc_server.rs
+++ b/backend/graph-proxy/src/test_oidc_server.rs
@@ -1,0 +1,76 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use axum_extra::headers::Authorization;
+use testcontainers::core::wait::HttpWaitStrategy;
+use testcontainers::core::WaitFor;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+
+pub struct TestOidcServer {
+    container: ContainerAsync<GenericImage>,
+    pub host: String,
+    pub port: u16,
+    pub issuer_url: String,
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+impl TestOidcServer {
+    pub async fn new() -> anyhow::Result<Self> {
+        let wait_strategy = HttpWaitStrategy::new("default/.well-known/openid-configuration")
+            .with_expected_status_code(200u16);
+        let oidc_container = GenericImage::new("ghcr.io/navikt/mock-oauth2-server", "3.0.1")
+            .with_wait_for(WaitFor::http(wait_strategy))
+            .with_env_var("SERVER_PORT", "8080")
+            .with_startup_timeout(Duration::from_secs(60))
+            .start()
+            .await
+            .expect("failed to start mock OIDC server");
+        let port = oidc_container.get_host_port_ipv4(8080).await?;
+        let host = oidc_container.get_host().await?.to_string();
+        let issuer_url = format!("http://{}:{}/default", host, port);
+        let server = TestOidcServer {
+            container: oidc_container,
+            host,
+            port,
+            issuer_url,
+            client_id: "test_client".to_string(),
+            client_secret: "test-secret".to_string(),
+        };
+        Ok(server)
+    }
+
+    pub async fn access_token(
+        &self,
+    ) -> anyhow::Result<Authorization<axum_extra::headers::authorization::Bearer>> {
+        let params = [
+            ("grant_type", "client_credentials"),
+            ("scope", "openid"),
+            ("subject", "test-subject"),
+            ("client_id", &self.client_id),
+            ("client_secret", &self.client_secret),
+        ];
+        let mock_admin_url = format!("http://{}:{}/default/token", self.host, self.port);
+        let response: serde_json::Value = reqwest::Client::new()
+            .post(mock_admin_url)
+            .timeout(Duration::from_secs(10))
+            .form(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+        let access_token = response
+            .get("access_token")
+            .context("no access token")?
+            .as_str()
+            .context("invalid access token")?;
+        let access_token = Authorization::bearer(access_token)?;
+        Ok(access_token)
+    }
+
+    pub async fn stop(self) -> anyhow::Result<()> {
+        self.container.stop_with_timeout(Some(60)).await?;
+        Ok(())
+    }
+}

--- a/backend/graph-proxy/src/validate_token.rs
+++ b/backend/graph-proxy/src/validate_token.rs
@@ -251,18 +251,12 @@ type ProviderMetadataWithInstrospectionEndpoint = ProviderMetadata<
 #[cfg(test)]
 mod tests {
 
-    use std::time::Duration;
-
-    use anyhow::Context;
     use axum::http::Uri;
-    use axum_extra::headers::Authorization;
     use rstest::rstest;
-    use testcontainers::core::wait::HttpWaitStrategy;
-    use testcontainers::core::WaitFor;
-    use testcontainers::runners::AsyncRunner;
-    use testcontainers::{GenericImage, ImageExt};
 
     use super::{TokenValidator, ValidatedAuthToken, ValidationMethod};
+
+    use crate::test_oidc_server::TestOidcServer;
 
     #[tokio::test]
     #[rstest]
@@ -274,45 +268,13 @@ mod tests {
             return Ok(());
         }
 
-        let wait_strategy = HttpWaitStrategy::new("default/.well-known/openid-configuration")
-            .with_expected_status_code(200u16);
-        let oidc_container = GenericImage::new("ghcr.io/navikt/mock-oauth2-server", "3.0.1")
-            .with_wait_for(WaitFor::http(wait_strategy))
-            .with_env_var("SERVER_PORT", "8080")
-            .with_startup_timeout(Duration::from_secs(60))
-            .start()
-            .await
-            .expect("failed to start mock OIDC server");
-        let port = oidc_container.get_host_port_ipv4(8080).await?;
-        let host = oidc_container.get_host().await?;
-        let mock_admin_url = format!("http://{}:{}/default/token", host, port);
-        let params = [
-            ("grant_type", "client_credentials"),
-            ("scope", "openid"),
-            ("subject", "test-subject"),
-            ("client_id", "test-client"),
-            ("client_secret", "test-secret"),
-        ];
+        let oidc_server = TestOidcServer::new().await?;
 
-        let response: serde_json::Value = reqwest::Client::new()
-            .post(mock_admin_url)
-            .timeout(Duration::from_secs(10))
-            .form(&params)
-            .send()
-            .await?
-            .json()
-            .await?;
-        let access_token = response
-            .get("access_token")
-            .context("no access token")?
-            .as_str()
-            .context("invalid access token")?;
-        let access_token = Authorization::bearer(access_token)?;
-        let issuer_url = format!("http://{}:{}/default", host, port).parse::<Uri>()?;
+        let access_token = oidc_server.access_token().await?;
 
         let token_validator = TokenValidator::new(
-            &issuer_url,
-            "test-client",
+            &oidc_server.issuer_url.parse::<Uri>()?,
+            &oidc_server.client_id,
             Some("test-secret".to_string()),
             vec!["workflows-cluster"],
         )
@@ -324,7 +286,8 @@ mod tests {
 
         assert_eq!(ValidatedAuthToken::Valid(access_token), authenticated_token);
 
-        oidc_container.stop_with_timeout(Some(60)).await?;
+        oidc_server.stop().await?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes a bug in graph-proxy that broke GraphQL subscriptions and produced: `"Authentication context missing"` errors visible in the console on the frontend.

This PR fixes bug and adds unit tests to prevent future regression.