### PR TITLE
fix(template-linter): filter out temporary files from lint results

### DIFF
--- a/workflows-cli/src/linter/helm.rs
+++ b/workflows-cli/src/linter/helm.rs
@@ -17,7 +17,12 @@ pub fn lint_from_helm(target: &Path, all: bool) -> Result<Vec<LintResult>, Strin
         .map_err(|_e| "Couldn't create temporary file for helm templates.")?;
 
     let path_buf = tmp_dir.to_path_buf();
-    lint_from_manifest(&path_buf, true)
+    let mut results = lint_from_manifest(&path_buf, true)?;
+
+    // Filter out tmp files
+    results.retain(|r| !r.template_name.starts_with("/tmp/argo-lint"));
+
+    Ok(results)
 }
 
 pub fn write_to_clean_folder(path: &Path, contents: Vec<String>) -> std::io::Result<()> {

--- a/workflows-cli/src/linter/helm.rs
+++ b/workflows-cli/src/linter/helm.rs
@@ -20,7 +20,7 @@ pub fn lint_from_helm(target: &Path, all: bool) -> Result<Vec<LintResult>, Strin
     let mut results = lint_from_manifest(&path_buf, true)?;
 
     // Filter out tmp files
-    results.retain(|r| !r.template_name.starts_with("/tmp/argo-lint"));
+    results.retain(|r| !r.name.starts_with("/tmp/argo-lint"));
 
     Ok(results)
 }


### PR DESCRIPTION
- Temporary files generated during linting were previously included in results, causing noise in CI and local lint outputs. This ensures only meaningful files are considered.
- Verified CI passes successfully after the change
- passed all CI checks including formatting, clippy, and build tests

