### PR TITLE
chore(charts): deploy identity-mapper to argus with policies disabled

### DIFF
--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: apps
 description: An argocd app to deploy apps inside the virtual cluster
 type: application
-version: 0.5.6
+version: 0.5.7

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -164,5 +164,5 @@ k6Operator:
   valuesObject: {}
 
 identityMapper:
-  enabled: false
+  enabled: true
   targetRevision: HEAD


### PR DESCRIPTION
Preparing Workflows for cloud team policy updates.

This deploys identity-mapper to main but with kyverno policies are disabled. It will sync LDAP information but will not apply them to Workflow pods until the polices are enabled.